### PR TITLE
Remove duplicate forward rule

### DIFF
--- a/_envcommon/services/ecs-eop-tileserver.hcl
+++ b/_envcommon/services/ecs-eop-tileserver.hcl
@@ -158,15 +158,7 @@ inputs = {
   }
 
   # Configure the ALB listener rules to redirect HTTP traffic to HTTPS
-  redirect_rules = {
-    "http-to-https" = {
-      listener_ports = [80]
-      status_code    = "HTTP_301"
-      port           = 443
-      protocol       = "HTTPS"
-      path_patterns  = ["/*"]
-    }
-  }
+  # This is handled in the ecs-eop-manager config, which uses the same ALB
 
   # -------------------------------------------------------------------------------------------------------------
   # CloudWatch Alarms


### PR DESCRIPTION
When adding the tileserver service, [a duplicate forward rule was created](https://github.com/Greater-Wellington-Regional-Council/Environmental-Outcomes-Platform-Infrastructure/pull/60/files#diff-101edf2cb3459167efae0f4966c51e64860df4ac574a24d6d4d85a04e470286eR161-R168) since the services share the same ALB. This simply cleans that up.
