### PR TITLE
Add Ingest API Infrastructure

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 terragrunt 0.42.7
 terraform 1.3.7
+python 3.7.16

--- a/_envcommon/data-stores/kafka.hcl
+++ b/_envcommon/data-stores/kafka.hcl
@@ -1,0 +1,41 @@
+terraform {
+  source = "../../../../..//modules//msk-serverless"
+}
+
+dependency "vpc" {
+  config_path = "${get_terragrunt_dir()}/../../networking/vpc"
+
+  mock_outputs = {
+    vpc_id                         = "vpc-abcd1234"
+    private_persistence_subnet_ids = ["subnet-abcd1234", "subnet-bcd1234a", ]
+    private_app_subnet_cidr_blocks = ["10.0.0.0/24", "10.0.1.0/24", ]
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+dependency "network_bastion" {
+  config_path = "${get_terragrunt_dir()}/../../../mgmt/bastion-host"
+
+  mock_outputs = {
+    security_group_id = "sg-abcd1234"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  account_name = local.account_vars.locals.account_name  
+}
+
+inputs = {
+  cluster_name    = "kafka-${lower(local.account_name)}"
+  cluster_size    = 3
+  kafka_version   = "3.3.1"
+  instance_type   = "kafka.t3.small"
+  vpc_id          = dependency.vpc.outputs.vpc_id
+  subnet_ids      = dependency.vpc.outputs.private_persistence_subnet_ids
+  allowed_inbound_cidr_blocks = dependency.vpc.outputs.private_app_subnet_cidr_blocks
+  allowed_inbound_security_group_ids = [dependency.network_bastion.outputs.bastion_host_security_group_id]
+  enable_client_sasl_scram = true
+}

--- a/_envcommon/data-stores/kafka.hcl
+++ b/_envcommon/data-stores/kafka.hcl
@@ -25,19 +25,19 @@ dependency "network_bastion" {
 
 locals {
   account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
-  account_name = local.account_vars.locals.account_name  
+  account_name = local.account_vars.locals.account_name
 }
 
 inputs = {
-  cluster_name    = "kafka-${lower(local.account_name)}"
-  cluster_size    = 3
-  kafka_version   = "3.3.1"
-  instance_type   = "kafka.t3.small"
-  vpc_id          = dependency.vpc.outputs.vpc_id
-  subnet_ids      = dependency.vpc.outputs.private_persistence_subnet_ids
-  allowed_inbound_cidr_blocks = dependency.vpc.outputs.private_app_subnet_cidr_blocks
+  cluster_name                       = "kafka-${lower(local.account_name)}"
+  cluster_size                       = 3
+  kafka_version                      = "3.3.1"
+  instance_type                      = "kafka.t3.small"
+  vpc_id                             = dependency.vpc.outputs.vpc_id
+  subnet_ids                         = dependency.vpc.outputs.private_persistence_subnet_ids
+  allowed_inbound_cidr_blocks        = dependency.vpc.outputs.private_app_subnet_cidr_blocks
   allowed_inbound_security_group_ids = [dependency.network_bastion.outputs.bastion_host_security_group_id]
-  enable_client_sasl_scram = true
+  enable_client_sasl_scram           = true
   server_properties = {
     "auto.create.topics.enable"  = "true"
     "default.replication.factor" = "2"

--- a/_envcommon/data-stores/kafka.hcl
+++ b/_envcommon/data-stores/kafka.hcl
@@ -38,4 +38,8 @@ inputs = {
   allowed_inbound_cidr_blocks = dependency.vpc.outputs.private_app_subnet_cidr_blocks
   allowed_inbound_security_group_ids = [dependency.network_bastion.outputs.bastion_host_security_group_id]
   enable_client_sasl_scram = true
+  server_properties = {
+    "auto.create.topics.enable"  = "true"
+    "default.replication.factor" = "2"
+  }
 }

--- a/_envcommon/mgmt/deploy_permissions.yml
+++ b/_envcommon/mgmt/deploy_permissions.yml
@@ -181,3 +181,17 @@ S3DeployAccess:
     - "s3:*"
   resources:
     - "*"
+
+MSKDeployAccess:
+  effect: "Allow"
+  actions:
+    - "kafka:*"
+  resources:
+    - "*"
+
+ApplicationAutoScalingDeployAccess:
+  effect: "Allow"
+  actions:
+    - "application-autoscaling:*"
+  resources:
+    - "*"

--- a/_envcommon/mgmt/read_only_permissions.yml
+++ b/_envcommon/mgmt/read_only_permissions.yml
@@ -233,3 +233,19 @@ S3StateBucketAccess:
   resources:
     - "arn:aws:s3:::${state_bucket}"
     - "arn:aws:s3:::${state_bucket}/*"
+
+MSKReadOnlyAccess:
+  effect: "Allow"
+  actions:
+    - "kafka:Describe*"
+    - "kafka:List*"
+    - "kafka:Get*"
+  resources:
+    - "*"
+
+ApplicationAutoScalingReadOnlyAccess:
+  effect: "Allow"
+  actions:
+    - "application-autoscaling:Describe*"
+  resources:
+    - "*"

--- a/_envcommon/networking/alb-eop-ingest-api.hcl
+++ b/_envcommon/networking/alb-eop-ingest-api.hcl
@@ -1,0 +1,73 @@
+terraform {
+  source = "${local.source_base_url}?ref=v0.96.9"
+}
+
+dependency "vpc" {
+  config_path = "${get_terragrunt_dir()}/../../networking/vpc"
+
+  mock_outputs = {
+    vpc_id            = "vpc-abcd1234"
+    public_subnet_ids = ["subnet-abcd1234", "subnet-bcd1234a", ]
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+dependency "route53" {
+  config_path = "${get_terragrunt_dir()}/../../../../_global/route53-public"
+
+  mock_outputs = {
+    public_hosted_zone_map = {
+      ("${local.account_vars.locals.domain_name.name}") = "some-zone"
+    }
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+locals {
+  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/alb"
+
+  # Automatically load common variables shared across all accounts
+  common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))
+
+  # Extract the name prefix for easy access
+  name_prefix = local.common_vars.locals.name_prefix
+
+  # Automatically load account-level variables
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract the account_name and account_role for easy access
+  account_name = local.account_vars.locals.account_name
+  account_role = local.account_vars.locals.account_role
+
+  # Automatically load region-level variables
+  region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  # Extract the region for easy access
+  aws_region = local.region_vars.locals.aws_region
+}
+
+inputs = {
+  # Since this is an external public facing ALB, we deploy it into the app VPC, inside the public tier.
+  is_internal_alb = false
+  vpc_id          = dependency.vpc.outputs.vpc_id
+  vpc_subnet_ids  = dependency.vpc.outputs.public_subnet_ids
+
+  # Since this is a public-facing ALB, we allow access from the entire Internet
+  allow_inbound_from_cidr_blocks = ["0.0.0.0/0"]
+
+  http_listener_ports = [80]
+  https_listener_ports_and_acm_ssl_certs = [
+    {
+      port            = 443
+      tls_domain_name = "${local.account_vars.locals.domain_name.name}"
+    }
+  ]
+
+  create_route53_entry = true
+  hosted_zone_id       = dependency.route53.outputs.public_hosted_zone_map[local.account_vars.locals.domain_name.name]
+  domain_names         = ["ingest.${local.account_vars.locals.domain_name.name}"]
+
+  num_days_after_which_archive_log_data = 7
+  num_days_after_which_delete_log_data  = 30
+  force_destroy                         = true
+}

--- a/_envcommon/services/ecs-eop-ingest-api.hcl
+++ b/_envcommon/services/ecs-eop-ingest-api.hcl
@@ -1,0 +1,230 @@
+terraform {
+  source = "${local.source_base_url}?ref=v0.100.0"
+}
+
+dependency "vpc" {
+  config_path = "${get_terragrunt_dir()}/../../networking/vpc"
+
+  mock_outputs = {
+    vpc_id = "vpc-abcd1234"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+dependency "ecs_fargate_cluster" {
+  config_path = "${get_terragrunt_dir()}/../ecs-fargate-cluster"
+
+  mock_outputs = {
+    ecs_cluster_arn  = "some-ecs-cluster-arn"
+    ecs_cluster_name = "ecs-cluster"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+dependency "sns" {
+  config_path = "${get_terragrunt_dir()}/../../../_regional/sns-topic"
+
+  mock_outputs = {
+    topic_arn = "arn:aws:sns:us-east-1:123456789012:mytopic-NZJ5JSMVGFIE"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+dependency "alb" {
+  config_path = "${get_terragrunt_dir()}/../../networking/alb-eop-manager"
+
+  mock_outputs = {
+    listener_arns = {
+      80  = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/mock-alb/50dc6c495c0c9188/f2f7dc8efc522ab2"
+      443 = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/mock-alb/50dc6c495c0c9188/f2f7dc8efc522ab2"
+    }
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Locals are named constants that are reusable within the configuration.
+# ---------------------------------------------------------------------------------------------------------------------
+locals {
+  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/services/ecs-service"
+
+  # Automatically load common variables shared across all accounts
+  common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))
+
+  # Extract the name prefix for easy access
+  name_prefix = local.common_vars.locals.name_prefix
+
+  # Automatically load account-level variables
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract the account_name for easy access
+  account_name = local.account_vars.locals.account_name
+
+  # Automatically load region-level variables
+  region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  # Extract the region for easy access
+  aws_region = local.region_vars.locals.aws_region
+
+  service_name = "eop-ingest-api"
+
+  # Define the container image. This will be used in the child config to combine with the specific image tag for the
+  # environment.
+  container_image = "898449181946.dkr.ecr.ap-southeast-2.amazonaws.com/eop-ingest-api"
+
+  module_config              = read_terragrunt_config("module_config.hcl")
+  config_secrets_manager_arn = local.module_config.locals.config_secrets_manager_arn
+  container_image_tag        = local.module_config.locals.container_image_tag
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above.
+# This defines the parameters that are common across all environments.
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {
+  # -------------------------------------------------------------------------------------------------------------------
+  # Cluster and container configuration
+  # -------------------------------------------------------------------------------------------------------------------
+
+  service_name     = local.service_name
+  ecs_cluster_name = dependency.ecs_fargate_cluster.outputs.name
+  ecs_cluster_arn  = dependency.ecs_fargate_cluster.outputs.arn
+
+  launch_type = "FARGATE"
+  task_cpu    = 1024
+  task_memory = 2048
+
+  network_mode = "awsvpc"
+  network_configuration = {
+    vpc_id  = dependency.vpc.outputs.vpc_id
+    subnets = dependency.vpc.outputs.private_app_subnet_ids
+
+    security_group_rules = {
+      AllowAllEgress = {
+        type                     = "egress"
+        from_port                = 0
+        to_port                  = 0
+        protocol                 = "-1"
+        cidr_blocks              = ["0.0.0.0/0"]
+        source_security_group_id = null
+      }
+      AllowALBIngress = {
+        type                     = "ingress"
+        from_port                = 443
+        to_port                  = 443
+        protocol                 = "TCP"
+        cidr_blocks              = null
+        source_security_group_id = dependency.alb.outputs.alb_security_group_id
+      }
+    }
+    additional_security_group_ids = []
+    assign_public_ip              = false
+  }
+
+  use_auto_scaling = false
+
+  custom_iam_policy_prefix = local.service_name
+
+  # --------------------------------------------------------------------------------------------------------------------
+  # ALB configuration
+  # We configure Target Groups for the ECS service so that the ALBs can route to the ECS tasks that are deployed on each
+  # node by the service.
+  # --------------------------------------------------------------------------------------------------------------------
+
+  elb_target_groups = {
+    alb = {
+      name                  = local.service_name
+      container_name        = local.service_name
+      container_port        = 443
+      protocol              = "HTTPS"
+      health_check_protocol = "HTTPS"
+    }
+  }
+  elb_target_group_deregistration_delay = 60
+  elb_target_group_vpc_id               = dependency.vpc.outputs.vpc_id
+  health_check_path                     = "/actuator/health"
+  default_listener_arns                 = dependency.alb.outputs.listener_arns
+  default_listener_ports                = ["443"]
+
+  # Configure the ALB listener rules to forward HTTPS traffic to the ECS service.
+  forward_rules = {
+    "default" = {
+      listener_arns = [dependency.alb.outputs.listener_arns["443"]]
+      port          = 443
+      path_patterns = ["/allocations"]
+    }
+  }
+
+  # -------------------------------------------------------------------------------------------------------------
+  # CloudWatch Alarms
+  # -------------------------------------------------------------------------------------------------------------
+
+  alarm_sns_topic_arns = [dependency.sns.outputs.topic_arn]
+
+  # -------------------------------------------------------------------------------------------------------------
+  # Private common inputs
+  # The following are common data (like locals) that can be used to construct the final input. We take advantage
+  # of the fact that Terraform ignores extraneous variables defined in Terragrunt to make this work. We use _ to
+  # denote these variables to avoid the chance of accidentally setting a real variable. We define these here
+  # instead of using locals because locals can not reference dependencies.
+  # -------------------------------------------------------------------------------------------------------------
+
+  # Refer to the AWS docs for supported options in the container definition:
+  # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html
+  container_definitions = [
+    {
+      name      = "${local.service_name}"
+      image     = "${local.container_image}:${local.container_image_tag}"
+      essential = true
+      environment = [
+        {
+          name  = "SERVER_PORT"
+          value = "443"
+        },
+        {
+          name  = "SPRING_PROFILES_ACTIVE"
+          value = "prod,ssl"
+        }
+      ]
+
+      secrets = [
+        {
+          name : "CONFIG_KEYSTORE_CONTENT",
+          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_KEYSTORE_CONTENT::"
+        },
+        {
+          name : "CONFIG_KEYSTORE_PASSWORD",
+          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_KEYSTORE_PASSWORD::"
+        },
+        {
+          name : "CONFIG_KEYSTORE_KEY",
+          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_KEYSTORE_KEY::"
+        },
+      ]
+
+      # The container ports that should be exposed from this container.
+      portMappings = [
+        {
+          "containerPort" = 443
+          "protocol"      = "tcp"
+        }
+      ]
+
+      # Configure log aggregation from the ECS service to stream to CloudWatch logs.
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          awslogs-group         = "/${local.account_name}/ecs/${local.service_name}"
+          awslogs-region        = local.aws_region
+          awslogs-stream-prefix = "ecs"
+          awslogs-create-group  = "true"
+        }
+      }
+    }
+  ]
+
+  secrets_manager_arns = [
+    local.config_secrets_manager_arn,
+  ]
+}

--- a/_envcommon/services/ecs-eop-ingest-api.hcl
+++ b/_envcommon/services/ecs-eop-ingest-api.hcl
@@ -31,7 +31,7 @@ dependency "sns" {
 }
 
 dependency "alb" {
-  config_path = "${get_terragrunt_dir()}/../../networking/alb-eop-manager"
+  config_path = "${get_terragrunt_dir()}/../../networking/alb-eop-ingest-api"
 
   mock_outputs = {
     listener_arns = {
@@ -152,9 +152,21 @@ inputs = {
     "default" = {
       listener_arns = [dependency.alb.outputs.listener_arns["443"]]
       port          = 443
-      path_patterns = ["/allocations"]
+      path_patterns = ["/*"]
+      priority      = 1
     }
   }
+
+  # Configure the ALB listener rules to redirect HTTP traffic to HTTPS
+  redirect_rules = {
+    "http-to-https" = {
+      listener_ports = [80]
+      status_code    = "HTTP_301"
+      port           = 443
+      protocol       = "HTTPS"
+      path_patterns  = ["/*"]
+    }
+  }  
 
   # -------------------------------------------------------------------------------------------------------------
   # CloudWatch Alarms

--- a/_envcommon/services/ecs-eop-ingest-api.hcl
+++ b/_envcommon/services/ecs-eop-ingest-api.hcl
@@ -74,6 +74,7 @@ locals {
 
   module_config              = read_terragrunt_config("module_config.hcl")
   config_secrets_manager_arn = local.module_config.locals.config_secrets_manager_arn
+  users_secrets_manager_arn = local.module_config.locals.users_secrets_manager_arn
   container_image_tag        = local.module_config.locals.container_image_tag
 }
 
@@ -213,6 +214,10 @@ inputs = {
           name : "CONFIG_KEYSTORE_KEY",
           valueFrom : "${local.config_secrets_manager_arn}:CONFIG_KEYSTORE_KEY::"
         },
+        {
+          name : "INGESTAPI_USERSJSON",
+          valueFrom : local.users_secrets_manager_arn
+        },        
       ]
 
       # The container ports that should be exposed from this container.
@@ -238,5 +243,6 @@ inputs = {
 
   secrets_manager_arns = [
     local.config_secrets_manager_arn,
+    local.users_secrets_manager_arn,
   ]
 }

--- a/_envcommon/services/ecs-eop-ingest-api.hcl
+++ b/_envcommon/services/ecs-eop-ingest-api.hcl
@@ -81,11 +81,11 @@ locals {
   # environment.
   container_image = "898449181946.dkr.ecr.ap-southeast-2.amazonaws.com/eop-ingest-api"
 
-  module_config              = read_terragrunt_config("module_config.hcl")
-  config_secrets_manager_arn = local.module_config.locals.config_secrets_manager_arn
-  users_secrets_manager_arn = local.module_config.locals.users_secrets_manager_arn
+  module_config                   = read_terragrunt_config("module_config.hcl")
+  config_secrets_manager_arn      = local.module_config.locals.config_secrets_manager_arn
+  users_secrets_manager_arn       = local.module_config.locals.users_secrets_manager_arn
   kafka_creds_secrets_manager_arn = local.module_config.locals.kafka_creds_secrets_manager_arn
-  container_image_tag        = local.module_config.locals.container_image_tag
+  container_image_tag             = local.module_config.locals.container_image_tag
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -177,7 +177,7 @@ inputs = {
       protocol       = "HTTPS"
       path_patterns  = ["/*"]
     }
-  }  
+  }
 
   # -------------------------------------------------------------------------------------------------------------
   # CloudWatch Alarms
@@ -238,7 +238,7 @@ inputs = {
         {
           name : "KAFKA_SASL_PASSWORD",
           valueFrom : "${local.kafka_creds_secrets_manager_arn}:password::"
-        },        
+        },
       ]
 
       # The container ports that should be exposed from this container.

--- a/eopdev/ap-southeast-2/eopdev/data-stores/kafka/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/eopdev/data-stores/kafka/terragrunt.hcl
@@ -1,0 +1,21 @@
+# Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
+include "root" {
+  path = find_in_parent_folders()
+}
+
+# Include the component configuration, which has settings that are common for the component across all environments
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/data-stores/kafka.hcl"
+  # We want to reference the variables from the included config in this configuration, so we expose it.
+  expose = true
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Module parameters to pass in. Note that these parameters are environment specific.
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {
+  name = "kafka-eopdev"
+  client_sasl_scram_secret_arns = [
+    "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:AmazonMSK_EOPIngestAPIKafkaCredentials-kndW0a"
+  ]
+}

--- a/eopdev/ap-southeast-2/eopdev/networking/alb-eop-ingest-api/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/eopdev/networking/alb-eop-ingest-api/terragrunt.hcl
@@ -1,0 +1,16 @@
+terraform {
+  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path   = "${dirname(find_in_parent_folders())}/_envcommon/networking/alb-eop-ingest-api.hcl"
+  expose = true
+}
+
+inputs = {
+  alb_name = "eop-ingest-dev"
+}

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
@@ -2,5 +2,6 @@
 locals {
   config_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIConfig-Sd0J4T"
   users_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIUsers-OGblpw"
-  container_image_tag        = "85448b44f03239b095203ee5e62fb081ab04aacd"
+  kafka_creds_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:AmazonMSK_EOPIngestAPIKafkaCredentials-kndW0a"
+  container_image_tag        = "d7d09bc751652bbbd0f2d165e382caf2e8fb3837"
 }

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
@@ -1,7 +1,7 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  config_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIConfig-Sd0J4T"
-  users_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIUsers-OGblpw"
+  config_secrets_manager_arn      = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIConfig-Sd0J4T"
+  users_secrets_manager_arn       = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIUsers-OGblpw"
   kafka_creds_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:AmazonMSK_EOPIngestAPIKafkaCredentials-kndW0a"
-  container_image_tag        = "eca3756b366b5d3f46847b74b46bc8613b4a94f2"
+  container_image_tag             = "eca3756b366b5d3f46847b74b46bc8613b4a94f2"
 }

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
@@ -1,5 +1,6 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
   config_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIConfig-Sd0J4T"
-  container_image_tag        = "fc39b18935476c1961501233f302defaedabb4a5"
+  users_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIUsers-OGblpw"
+  container_image_tag        = "85448b44f03239b095203ee5e62fb081ab04aacd"
 }

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
@@ -1,0 +1,5 @@
+# Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
+locals {
+  config_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIConfig-Sd0J4T"
+  container_image_tag        = "fc39b18935476c1961501233f302defaedabb4a5"
+}

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
@@ -3,5 +3,5 @@ locals {
   config_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIConfig-Sd0J4T"
   users_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIUsers-OGblpw"
   kafka_creds_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:AmazonMSK_EOPIngestAPIKafkaCredentials-kndW0a"
-  container_image_tag        = "d7d09bc751652bbbd0f2d165e382caf2e8fb3837"
+  container_image_tag        = "eca3756b366b5d3f46847b74b46bc8613b4a94f2"
 }

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/terragrunt.hcl
@@ -1,0 +1,10 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/services/ecs-eop-ingest-api.hcl"
+}
+
+inputs = {
+}

--- a/modules/cdn/main.tf
+++ b/modules/cdn/main.tf
@@ -66,7 +66,7 @@ module "access_logs" {
 
   bucket_policy_statements = {
     AllowCloudfrontWriteS3AccessLog = {
-      effect = "Allow"
+      effect  = "Allow"
       actions = ["s3:*"]
       principals = {
         "AWS" = ["arn:aws:iam::162777425019:root"]

--- a/modules/msk-serverless/main.tf
+++ b/modules/msk-serverless/main.tf
@@ -1,0 +1,250 @@
+# Based on https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/msk
+# Adapted to use https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_serverless_cluster
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# RUN AN AMAZON MANAGED STREAMING FOR KAFKA (MSK) CLUSTER
+# These templates launch an MSK cluster resource that manages the Kafka cluster. This includes:
+# - Security group and rules based on selected auth method
+# - Storage autoscaling
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# ---------------------------------------------------------------------------------------------------------------------
+# SET TERRAFORM REQUIREMENTS FOR RUNNING THIS MODULE
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  # This module is now only being tested with Terraform 1.1.x. However, to make upgrading easier, we are setting 1.0.0 as the minimum version.
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.75.1"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# PREPARE LOCALS
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # Construct a properties file format from the properties map
+  server_properties = join("\n", [for k, v in var.server_properties : "${k}=${v}"])
+
+  # Determine allowed ports
+  allow_plaintext_9092  = contains(["PLAINTEXT", "TLS_PLAINTEXT"], var.encryption_in_transit_client_broker)
+  allow_tls_9094        = contains(["TLS", "TLS_PLAINTEXT"], var.encryption_in_transit_client_broker)
+  allow_sasl_scram_9096 = var.enable_client_sasl_scram && contains(["TLS", "TLS_PLAINTEXT"], var.encryption_in_transit_client_broker)
+  allow_sasl_iam_9098   = var.enable_client_sasl_iam && contains(["TLS", "TLS_PLAINTEXT"], var.encryption_in_transit_client_broker)
+
+  # Clean up ports
+  all_ports = [for port in [
+    local.allow_plaintext_9092 ? 9092 : 0,
+    local.allow_tls_9094 ? 9094 : 0,
+    local.allow_sasl_scram_9096 ? 9096 : 0,
+    local.allow_sasl_iam_9098 ? 9098 : 0,
+    # Always allow Zookeeper ports
+    2181,
+    2182
+  ] : port if port != 0]
+
+  # Construct a product on configured ports and allowed security groups
+  allowed_security_groups_with_all_ports = setproduct(var.allowed_inbound_security_group_ids, local.all_ports)
+
+  cluster_topic_arn_prefix = "arn:${data.aws_partition.current.partition}:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${var.cluster_name}"
+  cluster_group_arn_prefix = "arn:${data.aws_partition.current.partition}:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${var.cluster_name}"
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE THE MSK CLUSTER SECURITY GROUP
+# Limits which ports are allowed inbound and outbound on the broker nodes.
+# We export the security group id as an output so users of this module can add their own custom rules.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_security_group" "msk" {
+  name        = var.cluster_name
+  description = "Security Group for ${var.cluster_name} MSK Cluster"
+  vpc_id      = var.vpc_id
+  tags        = var.custom_tags_security_group
+}
+
+# Allow all outbound
+resource "aws_security_group_rule" "allow_outbound_all" {
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = aws_security_group.msk.id
+}
+
+# Allow inbound from provided CIDR blocks
+resource "aws_security_group_rule" "allow_inbound_cidr" {
+  count             = length(var.allowed_inbound_cidr_blocks)
+  type              = "ingress"
+  from_port         = local.all_ports[count.index]
+  to_port           = local.all_ports[count.index]
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_inbound_cidr_blocks
+  security_group_id = aws_security_group.msk.id
+}
+
+# Allow inbound from provided security groups
+resource "aws_security_group_rule" "allow_inbound_sg" {
+  count                    = length(local.allowed_security_groups_with_all_ports)
+  type                     = "ingress"
+  from_port                = local.allowed_security_groups_with_all_ports[count.index][1]
+  to_port                  = local.allowed_security_groups_with_all_ports[count.index][1]
+  protocol                 = "tcp"
+  source_security_group_id = local.allowed_security_groups_with_all_ports[count.index][0]
+  security_group_id        = aws_security_group.msk.id
+}
+
+# Allow inbound from self
+resource "aws_security_group_rule" "allow_inbound_self" {
+  count             = length(local.all_ports)
+  type              = "ingress"
+  from_port         = local.all_ports[count.index]
+  to_port           = local.all_ports[count.index]
+  protocol          = "tcp"
+  self              = true
+  security_group_id = aws_security_group.msk.id
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE THE MSK CONFIGURATION AND CLUSTER
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_msk_configuration" "msk" {
+  kafka_versions = [var.kafka_version]
+  name           = var.cluster_name
+  description    = "MSK configuration for cluster ${var.cluster_name}"
+
+  server_properties = local.server_properties
+}
+
+resource "aws_msk_cluster" "msk" {
+  cluster_name           = var.cluster_name
+  kafka_version          = var.kafka_version
+  number_of_broker_nodes = var.cluster_size
+  enhanced_monitoring    = var.enhanced_monitoring
+
+  configuration_info {
+    arn      = aws_msk_configuration.msk.arn
+    revision = aws_msk_configuration.msk.latest_revision
+  }
+
+  broker_node_group_info {
+    instance_type   = var.instance_type
+    ebs_volume_size = var.initial_ebs_volume_size
+    client_subnets  = var.subnet_ids
+    security_groups = concat(compact(var.additional_security_group_ids), [aws_security_group.msk.id])
+  }
+
+  encryption_info {
+    encryption_in_transit {
+      client_broker = var.encryption_in_transit_client_broker
+      in_cluster    = var.encryption_in_transit_in_cluster
+    }
+    encryption_at_rest_kms_key_arn = var.encryption_at_rest_kms_key_arn
+  }
+
+  dynamic "client_authentication" {
+    for_each = var.enable_client_tls || var.enable_client_sasl_scram || var.enable_client_sasl_iam ? ["auth"] : []
+    content {
+      dynamic "tls" {
+        for_each = var.enable_client_tls ? ["tls"] : []
+        content {
+          certificate_authority_arns = var.client_tls_certificate_authority_arns
+        }
+      }
+      dynamic "sasl" {
+        for_each = var.enable_client_sasl_scram || var.enable_client_sasl_iam ? ["sasl"] : []
+        content {
+          scram = var.enable_client_sasl_scram
+          iam   = var.enable_client_sasl_iam
+        }
+      }
+    }
+  }
+
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = var.enable_cloudwatch_logs
+        log_group = var.cloudwatch_log_group
+      }
+      firehose {
+        enabled         = var.enable_firehose_logs
+        delivery_stream = var.firehose_delivery_stream
+      }
+      s3 {
+        enabled = var.enable_s3_logs
+        bucket  = var.s3_logs_bucket
+        prefix  = var.s3_logs_prefix
+      }
+    }
+  }
+
+  open_monitoring {
+    prometheus {
+      jmx_exporter {
+        enabled_in_broker = var.open_monitoring_enable_jmx_exporter
+      }
+      node_exporter {
+        enabled_in_broker = var.open_monitoring_enable_node_exporter
+      }
+    }
+  }
+
+  tags = var.custom_tags
+
+  # Ignore changes to the broker volume, because 'aws_appautoscaling_policy' will take care of scaling the volume
+  lifecycle {
+    ignore_changes = [broker_node_group_info[0].ebs_volume_size]
+  }
+}
+
+# AWS Secrets Manager holds entries for username and password authentication for a cluster.
+# You will have to create the Secrets Manager secrets separately. For full details, see
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_scram_secret_association
+resource "aws_msk_scram_secret_association" "default" {
+  count = var.enable_client_sasl_scram && length(var.client_sasl_scram_secret_arns) > 0 ? 1 : 0
+
+  cluster_arn     = aws_msk_cluster.msk.arn
+  secret_arn_list = var.client_sasl_scram_secret_arns
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# BROKER STORAGE AUTOSCALING
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_appautoscaling_target" "msk" {
+  max_capacity       = var.broker_storage_autoscaling_max_capacity
+  min_capacity       = 1
+  role_arn           = var.override_broker_storage_autoscaling_role_arn
+  resource_id        = aws_msk_cluster.msk.arn
+  scalable_dimension = "kafka:broker-storage:VolumeSize"
+  service_namespace  = "kafka"
+}
+
+resource "aws_appautoscaling_policy" "msk" {
+  name               = "${var.cluster_name}-broker-storage-scaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_msk_cluster.msk.arn
+  scalable_dimension = aws_appautoscaling_target.msk.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.msk.service_namespace
+  target_tracking_scaling_policy_configuration {
+    disable_scale_in = var.disable_broker_storage_scale_in
+    predefined_metric_specification {
+      predefined_metric_type = "KafkaBrokerStorageUtilization"
+    }
+
+    target_value = var.broker_storage_autoscaling_target_percentage
+  }
+}

--- a/modules/msk-serverless/outputs.tf
+++ b/modules/msk-serverless/outputs.tf
@@ -1,0 +1,74 @@
+output "cluster_name" {
+  description = "Name of the MSK cluster."
+  value       = aws_msk_cluster.msk.cluster_name
+}
+
+output "cluster_arn" {
+  description = "ARN of the MSK cluster."
+  value       = aws_msk_cluster.msk.arn
+}
+
+output "cluster_current_version" {
+  description = "Current version of the MSK Cluster used for updates"
+  value       = aws_msk_cluster.msk.current_version
+}
+
+output "bootstrap_brokers" {
+  description = "A comma separated list of one or more hostname:port pairs of kafka brokers suitable to boostrap connectivity to the kafka cluster"
+  value       = aws_msk_cluster.msk.bootstrap_brokers
+}
+
+output "bootstrap_brokers_tls" {
+  description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster"
+  value       = aws_msk_cluster.msk.bootstrap_brokers_tls
+}
+
+output "bootstrap_brokers_scram" {
+  description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity using SASL/SCRAM to the kafka cluster."
+  value       = aws_msk_cluster.msk.bootstrap_brokers_sasl_scram
+}
+
+output "bootstrap_brokers_iam" {
+  description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity using SASL/IAM to the kafka cluster."
+  value       = aws_msk_cluster.msk.bootstrap_brokers_sasl_iam
+}
+
+output "zookeeper_connect_string" {
+  description = "A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster"
+  value       = aws_msk_cluster.msk.zookeeper_connect_string
+}
+
+output "zookeeper_connect_string_tls" {
+  description = "A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster"
+  value       = aws_msk_cluster.msk.zookeeper_connect_string_tls
+}
+
+output "msk_config_arn" {
+  description = "ARN of the MSK configuration."
+  value       = aws_msk_configuration.msk.arn
+}
+
+output "msk_config_latest_revision" {
+  description = "Latest revision of the MSK configuration."
+  value       = aws_msk_configuration.msk.latest_revision
+}
+
+output "security_group_id" {
+  description = "The ID of the cluster security group."
+  value       = aws_security_group.msk.id
+}
+
+output "security_group_name" {
+  description = "The name of the cluster security group."
+  value       = aws_security_group.msk.name
+}
+
+output "cluster_topic_arn_prefix" {
+  description = "Topic ARN prefix (without trailing '/') to help creating IAM policies, e.g. 'arn:aws:kafka:us-east-1:0123456789012:topic/MyTestCluster'"
+  value       = local.cluster_topic_arn_prefix
+}
+
+output "cluster_group_arn_prefix" {
+  description = "Group ARN prefix (without trailing '/') to help creating IAM policies, e.g. 'arn:aws:kafka:us-east-1:0123456789012:group/MyTestCluster'"
+  value       = local.cluster_group_arn_prefix
+}

--- a/modules/msk-serverless/variables.tf
+++ b/modules/msk-serverless/variables.tf
@@ -1,0 +1,238 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "cluster_name" {
+  description = "The name of the Kafka cluster (e.g. kafka-stage). This variable is used to namespace all resources created by this module."
+  type        = string
+}
+
+variable "cluster_size" {
+  description = "The number of brokers to have in the cluster."
+  type        = number
+}
+
+variable "kafka_version" {
+  description = "Kafka version to install. See https://docs.aws.amazon.com/msk/latest/developerguide/supported-kafka-versions.html for a list of supported versions."
+  type        = string
+}
+
+variable "instance_type" {
+  description = "Specify the instance type to use for the kafka brokers (e.g. `kafka.m5.large`). See https://docs.aws.amazon.com/msk/latest/developerguide/msk-create-cluster.html#broker-instance-types for available instance types."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC in which to deploy the cluster."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "The subnet IDs into which the broker instances should be deployed. You should typically pass in one subnet ID per node in the cluster_size variable. The number of broker nodes must be a multiple of subnets. We strongly recommend that you run Kafka in private subnets."
+  type        = list(string)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# General settings
+variable "server_properties" {
+  type        = map(string)
+  default     = {}
+  description = "Contents of the server.properties file. Supported properties are documented in the MSK Developer Guide (https://docs.aws.amazon.com/msk/latest/developerguide/msk-configuration-properties.html)."
+
+  # Example:
+  #   {
+  #     "auto.create.topics.enable" = "true"
+  #     "default.replication.factor" = "2"
+  #   }
+}
+
+variable "enhanced_monitoring" {
+  description = "Specify the desired enhanced MSK CloudWatch monitoring level. See https://docs.aws.amazon.com/msk/latest/developerguide/metrics-details.html for valid values."
+  type        = string
+  default     = "DEFAULT"
+}
+
+variable "custom_tags" {
+  description = "Custom tags to apply to the Kafka broker nodes and all related resources."
+  type        = map(string)
+  default     = {}
+
+  # Example:
+  #   {
+  #     key1 = "value1"
+  #     key2 = "value2"
+  #   }
+}
+
+# Broker storage settings
+variable "initial_ebs_volume_size" {
+  description = "The initial size of the EBS volume (in GiB) for the data drive on each broker node. "
+  type        = number
+  default     = 50
+}
+
+variable "broker_storage_autoscaling_max_capacity" {
+  description = "Max capacity of broker node EBS storage (in GiB)"
+  type        = number
+  default     = 100
+}
+
+variable "broker_storage_autoscaling_target_percentage" {
+  description = "Broker storage utilization percentage at which scaling is triggered."
+  type        = number
+  default     = 70
+}
+
+variable "disable_broker_storage_scale_in" {
+  description = "Flag indicating whether broker storage should never be scaled in."
+  type        = bool
+  default     = false
+}
+
+variable "override_broker_storage_autoscaling_role_arn" {
+  description = "Override automatically created Service-linked role for storage autoscaling. If not provided, Application Auto Scaling creates the appropriate service-linked role for you."
+  type        = string
+  default     = null
+}
+
+# Access settings
+variable "allowed_inbound_cidr_blocks" {
+  description = "A list of CIDR-formatted IP address ranges that will be allowed to connect to the Kafka brokers."
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_inbound_security_group_ids" {
+  description = "A list of security group IDs that will be allowed to connect to the Kafka brokers."
+  type        = list(string)
+  default     = []
+}
+
+# Security group settings
+variable "additional_security_group_ids" {
+  description = "A list of Security Group IDs that should be added to the MSK cluster broker instances."
+  type        = list(string)
+  default     = []
+}
+
+variable "custom_tags_security_group" {
+  description = "A map of custom tags to apply to the Security Group for this MSK Cluster. The key is the tag name and the value is the tag value."
+  type        = map(string)
+  default     = {}
+
+  # Example:
+  #   {
+  #     key1 = "value1"
+  #     key2 = "value2"
+  #   }
+}
+
+# Encryption settings
+variable "encryption_at_rest_kms_key_arn" {
+  description = "You may specify a KMS key short ID or ARN (it will always output an ARN) to use for encrypting your data at rest. If no key is specified, an AWS managed KMS ('aws/msk' managed service) key will be used for encrypting the data at rest."
+  type        = string
+  default     = null
+}
+
+variable "encryption_in_transit_client_broker" {
+  description = "Encryption setting for data in transit between clients and brokers. Valid values: TLS, TLS_PLAINTEXT, and PLAINTEXT. Default value is `TLS`."
+  type        = string
+  default     = "TLS"
+}
+
+variable "encryption_in_transit_in_cluster" {
+  description = "Whether data communication among broker nodes is encrypted. Default value: true."
+  type        = bool
+  default     = true
+}
+
+# Client settings
+variable "enable_client_sasl_scram" {
+  description = "Whether SASL SCRAM client authentication is enabled."
+  type        = bool
+  default     = false
+}
+
+variable "client_sasl_scram_secret_arns" {
+  description = "List of ARNs for SCRAM secrets stored in the Secrets Manager service."
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_client_sasl_iam" {
+  description = "Whether SASL IAM client authentication is enabled."
+  type        = bool
+  default     = false
+}
+
+variable "enable_client_tls" {
+  description = "Whether TLS client authentication is enabled."
+  type        = bool
+  default     = false
+}
+
+variable "client_tls_certificate_authority_arns" {
+  type        = list(string)
+  default     = []
+  description = "Optional list of ACM Certificate Authority Amazon Resource Names (ARNs)."
+}
+
+# Monitoring settings
+variable "open_monitoring_enable_jmx_exporter" {
+  description = "Indicates whether you want to enable or disable the Prometheus JMX Exporter."
+  type        = bool
+  default     = true
+}
+
+variable "open_monitoring_enable_node_exporter" {
+  description = "Indicates whether you want to enable or disable the Prometheus Node Exporter."
+  type        = bool
+  default     = true
+}
+
+# Logging setting
+variable "enable_cloudwatch_logs" {
+  description = "Indicates whether you want to enable or disable streaming broker logs to Cloudwatch Logs."
+  type        = bool
+  default     = false
+}
+
+variable "cloudwatch_log_group" {
+  description = "Name of the Cloudwatch Log Group to deliver logs to."
+  type        = string
+  default     = null
+}
+
+variable "enable_firehose_logs" {
+  description = "Indicates whether you want to enable or disable streaming broker logs to Kinesis Data Firehose."
+  type        = bool
+  default     = false
+}
+
+variable "firehose_delivery_stream" {
+  description = "Name of the Kinesis Data Firehose delivery stream to deliver logs to."
+  type        = string
+  default     = null
+}
+
+variable "enable_s3_logs" {
+  description = "Indicates whether you want to enable or disable streaming broker logs to S3."
+  type        = bool
+  default     = false
+}
+
+variable "s3_logs_bucket" {
+  description = "Name of the S3 bucket to deliver logs to."
+  type        = string
+  default     = null
+}
+variable "s3_logs_prefix" {
+  description = "Prefix to append to the folder name."
+  type        = string
+  default     = null
+}

--- a/shared/ap-southeast-2/_regional/ecr-repos/repos.yml
+++ b/shared/ap-southeast-2/_regional/ecr-repos/repos.yml
@@ -7,22 +7,22 @@
 
 ecs-deploy-runner:
   external_account_ids_with_read_access:
-  # NOTE: we have to comment out the directives so that the python based data merger (see the `merge-data` hook under
-  # blueprints in this repository) can parse this yaml file. This still works when feeding through templatefile, as it
-  # will interleave blank comments with the list items, which yaml handles gracefully.
-  # %{ for account_id in account_ids }
-  - '${account_id}'
+    # NOTE: we have to comment out the directives so that the python based data merger (see the `merge-data` hook under
+    # blueprints in this repository) can parse this yaml file. This still works when feeding through templatefile, as it
+    # will interleave blank comments with the list items, which yaml handles gracefully.
+    # %{ for account_id in account_ids }
+    - "${account_id}"
   # %{ endfor }
   external_account_ids_with_write_access: []
   tags: {}
   enable_automatic_image_scanning: true
 kaniko:
   external_account_ids_with_read_access:
-  # NOTE: we have to comment out the directives so that the python based data merger (see the `merge-data` hook under
-  # blueprints in this repository) can parse this yaml file. This still works when feeding through templatefile, as it
-  # will interleave blank comments with the list items, which yaml handles gracefully.
-  # %{ for account_id in account_ids }
-  - '${account_id}'
+    # NOTE: we have to comment out the directives so that the python based data merger (see the `merge-data` hook under
+    # blueprints in this repository) can parse this yaml file. This still works when feeding through templatefile, as it
+    # will interleave blank comments with the list items, which yaml handles gracefully.
+    # %{ for account_id in account_ids }
+    - "${account_id}"
   # %{ endfor }
   external_account_ids_with_write_access: []
   tags: {}
@@ -34,12 +34,23 @@ eop-manager:
     # blueprints in this repository) can parse this yaml file. This still works when feeding through templatefile, as it
     # will interleave blank comments with the list items, which yaml handles gracefully.
     # %{ for account_id in account_ids }
-    - '${account_id}'
+    - "${account_id}"
   # %{ endfor }
   external_account_ids_with_write_access: []
   tags: {}
   enable_automatic_image_scanning: true
 
+eop-ingest-api:
+  external_account_ids_with_read_access:
+    # NOTE: we have to comment out the directives so that the python based data merger (see the `merge-data` hook under
+    # blueprints in this repository) can parse this yaml file. This still works when feeding through templatefile, as it
+    # will interleave blank comments with the list items, which yaml handles gracefully.
+    # %{ for account_id in account_ids }
+    - "${account_id}"
+  # %{ endfor }
+  external_account_ids_with_write_access: []
+  tags: {}
+  enable_automatic_image_scanning: true
 # Add each repo you wish to create as a map:
 #
 # NAME:


### PR DESCRIPTION
### Summary of changes here:
- Create a module based on the [Terragrunt MSK module](https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/msk), with the intent of adapting it for MSK Serverless. (Note: this hasn't been adapted yet).
- Use this module to provision a Kafka cluster
- Add permissions to deploy roles to allow them to interact with AWS MSK and AWS application-autoscaling (which MSK depends on)
- Define a new ECR repo, ALB and ECS Service for the Ingest API, based on the existing Manager service

### Resource provisioned manually (in dev):
- KMS / eop-secretsmanager-kafka-sasl-creds
- SSM / AmazonMSK_EOPIngestAPIKafkaCredentials
- SSM / EOPIngestAPIUsers
- SSM / EOPIngestAPIConfig

### Things left to consider and potentially card:
- Should we switch to MSK Serverless?
  - If so, card the change, which will require switching to [IAM auth](https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html) since SASL is not supported
- Do we want to use any custom Kafka config that differs from [defaults](https://docs.aws.amazon.com/msk/latest/developerguide/msk-default-configuration.html)
- [Logging](https://github.com/gruntwork-io/terraform-aws-messaging/blob/main/modules/msk/main.tf#L173-L189)
- Once we've confirmed the above, can we simplify our MSK module by removing any unused TF code, variables and outputs
- How do we handle merging this PR considering the upcoming prod deploy?
- Applying the final changes to staging
- Documentation