### PR TITLE
Adding EOP specific alerting

### DIFF
--- a/_envcommon/services/eop-monitoring.hcl
+++ b/_envcommon/services/eop-monitoring.hcl
@@ -1,0 +1,42 @@
+terraform {
+  source = "../../../../..//modules//eop-monitoring"
+}
+
+dependency "sns" {
+  config_path = "${get_terragrunt_dir()}/../../../_regional/sns-topic"
+
+  mock_outputs = {
+    topic_arn = "arn:aws:sns:us-east-1:123456789012:mytopic-NZJ5JSMVGFIE"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+dependency "alb-eop-manager" {
+  config_path = "${get_terragrunt_dir()}/../../networking/alb-eop-manager"
+
+  mock_outputs = {
+    alb_arn = "arn:aws:elasticloadbalancing:ap-southeast-2:123456:loadbalancer/app/name/123456789"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+dependency "ecs-eop-manager" {
+  config_path = "${get_terragrunt_dir()}/../ecs-eop-manager"
+
+  mock_outputs = {
+    service_arn = "arn:aws:ecs:ap-southeast-2:123456789:service/name/name"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  account_name = local.account_vars.locals.account_name
+  service_name = "eop-manager"
+}
+
+inputs = {
+  eop_manager_log_group_name = "/${local.account_name}/ecs/${local.service_name}"
+  alarms_sns_topic_arn       = [dependency.sns.outputs.topic_arn]
+  eop_alb_arn                = dependency.alb-eop-manager.outputs.alb_arn
+}

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-manager/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-manager/module_config.hcl
@@ -1,5 +1,5 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
   config_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPManagerConfig-cWXx3Q"
-  container_image_tag        = "dc83ca1882c26e8af5991b750d6f5a788614f80a"
+  container_image_tag        = "91b9c5ebca56495ed62829a259fcf20c66360ca4"
 }

--- a/eopdev/ap-southeast-2/eopdev/services/eop-monitoring/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/eop-monitoring/terragrunt.hcl
@@ -1,0 +1,6 @@
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/services/eop-monitoring.hcl"
+}
+
+inputs = {
+}

--- a/eopprod/ap-southeast-2/eopprod/services/ecs-eop-manager/module_config.hcl
+++ b/eopprod/ap-southeast-2/eopprod/services/ecs-eop-manager/module_config.hcl
@@ -1,5 +1,5 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
   config_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:422253851608:secret:EOPManagerConfig-NU6YXY"
-  container_image_tag        = "dc83ca1882c26e8af5991b750d6f5a788614f80a"
+  container_image_tag        = "91b9c5ebca56495ed62829a259fcf20c66360ca4"
 }

--- a/eopprod/ap-southeast-2/eopprod/services/eop-monitoring/terragrunt.hcl
+++ b/eopprod/ap-southeast-2/eopprod/services/eop-monitoring/terragrunt.hcl
@@ -1,0 +1,6 @@
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/services/eop-monitoring.hcl"
+}
+
+inputs = {
+}

--- a/eopstage/ap-southeast-2/eopstage/services/ecs-eop-manager/module_config.hcl
+++ b/eopstage/ap-southeast-2/eopstage/services/ecs-eop-manager/module_config.hcl
@@ -1,5 +1,5 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
   config_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:564180615104:secret:EOPManagerConfig-m0z3Sp"
-  container_image_tag        = "dc83ca1882c26e8af5991b750d6f5a788614f80a"
+  container_image_tag        = "91b9c5ebca56495ed62829a259fcf20c66360ca4"
 }

--- a/eopstage/ap-southeast-2/eopstage/services/eop-monitoring/terragrunt.hcl
+++ b/eopstage/ap-southeast-2/eopstage/services/eop-monitoring/terragrunt.hcl
@@ -1,0 +1,6 @@
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/services/eop-monitoring.hcl"
+}
+
+inputs = {
+}

--- a/modules/eop-monitoring/main.tf
+++ b/modules/eop-monitoring/main.tf
@@ -205,6 +205,47 @@ resource "aws_cloudwatch_dashboard" "main" {
       },
       {
         height = 6,
+        width  = 6,
+        y      = 10,
+        x      = 18,
+        type   = "metric",
+
+        properties = {
+          metrics = [
+            [{ expression = "METRICS() * 1000", label = "to Millis", id : "e1", region : var.aws_region }],
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", replace(data.aws_arn.eop_alb_arn.resource, "loadbalancer/", ""), { stat = "Average", id = "m1", visible = false }],
+            ["...", { stat = "Maximum", id = "m2", visible = false }],
+            ["...", { stat = "p99", id = "m3", visible = false }]
+
+          ],
+          view     = "timeSeries",
+          stacked  = false,
+          region   = var.aws_region,
+          period   = 300,
+          title    = "API Response Times",
+          liveData = true,
+          yAxis = {
+            right = {
+              showUnits = false
+            }
+            left = {
+              showUnits = false
+              label     = "Millis"
+            }
+          }
+          annotations = {
+            horizontal = [
+              {
+                label = "Goal",
+                value = 3000,
+                fill  = "above"
+              }
+            ]
+          }
+        }
+      },
+      {
+        height = 6,
         width  = 24,
         y      = 16,
         x      = 0,
@@ -228,7 +269,7 @@ resource "aws_cloudwatch_dashboard" "main" {
           region  = var.aws_region,
           stacked = false,
           view    = "table",
-          title   = "Tile Server Logs"
+          title   = "Latest Tile Server Logs"
         }
       },
 

--- a/modules/eop-monitoring/main.tf
+++ b/modules/eop-monitoring/main.tf
@@ -8,11 +8,11 @@ locals {
 
 resource "aws_cloudwatch_log_metric_filter" "manager_log_errors" {
   name           = "Manager Log Error Messages"
-  pattern        = "?\" ERROR \" ?\" WARN \""
+  pattern        = "?\" WARN \" ?\" ERROR \""
   log_group_name = local.manager_log_group_name
 
   metric_transformation {
-    name          = "ErrorMessageEventCount"
+    name          = "ManagerErrorMessageEventCount"
     namespace     = "EOP"
     value         = "1"
     default_value = "0"
@@ -25,14 +25,41 @@ resource "aws_cloudwatch_metric_alarm" "manager_log_errors_alarm" {
   evaluation_periods  = "1"
   threshold           = "1"
   namespace           = "EOP"
-  metric_name         = "ErrorMessageEventCount"
+  metric_name         = "ManagerErrorMessageEventCount"
   period              = "300"
   statistic           = "Sum"
   alarm_description   = "This metric monitors error log records in the EOP Manager log file."
   treat_missing_data  = "notBreaching"
 
   alarm_actions = var.alarms_sns_topic_arn
+}
 
+resource "aws_cloudwatch_log_metric_filter" "tileserver_log_errors" {
+  name           = "Tileserver Log Error Messages"
+  pattern        = "?\"=warning\" ?\"=error\" ?\"=panic\" ?\"=fatal\""
+  log_group_name = local.tileserver_log_group_name
+
+  metric_transformation {
+    name          = "TileserverErrorMessageEventCount"
+    namespace     = "EOP"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "tileserver_log_errors_alarm" {
+  alarm_name          = "eop-tileserver-log-errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  threshold           = "1"
+  namespace           = "EOP"
+  metric_name         = "TileserverErrorMessageEventCount"
+  period              = "300"
+  statistic           = "Sum"
+  alarm_description   = "This metric monitors error log records in the EOP Tileserver log file."
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = var.alarms_sns_topic_arn
 }
 
 data "aws_arn" "eop_alb_arn" {

--- a/modules/eop-monitoring/main.tf
+++ b/modules/eop-monitoring/main.tf
@@ -1,0 +1,80 @@
+resource "aws_cloudwatch_log_metric_filter" "manager_log_errors" {
+  name           = "Manager Log Error Messages"
+  pattern        = "\" ERROR \""
+  log_group_name = var.eop_manager_log_group_name
+
+  metric_transformation {
+    name          = "ErrorMessageEventCount"
+    namespace     = "EOP"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "manager_log_errors_alarm" {
+  alarm_name          = "eop-manager-log-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  threshold           = "1"
+  namespace           = "EOP"
+  metric_name         = "ErrorMessageEventCount"
+  period              = "900"
+  statistic           = "Sum"
+  alarm_description   = "This metric monitors error log records in the EOP Manager log file."
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = var.alarms_sns_topic_arn
+
+}
+
+resource "aws_cloudwatch_log_metric_filter" "manager_log_warnings" {
+  name           = "Manager Log Warning Messages"
+  pattern        = "\" WARN \""
+  log_group_name = var.eop_manager_log_group_name
+
+  metric_transformation {
+    name          = "WarningMessageEventCount"
+    namespace     = "EOP"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "manager_log_warnings_alarm" {
+  alarm_name          = "eop-manager-log-warnings"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  threshold           = "1"
+  namespace           = "EOP"
+  metric_name         = "WarningMessageEventCount"
+  period              = "900"
+  statistic           = "Sum"
+  alarm_description   = "This metric monitors warning log records in the EOP Manager log file."
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = var.alarms_sns_topic_arn
+
+}
+
+data "aws_arn" "eop_alb_arn" {
+  arn = var.eop_alb_arn
+}
+
+resource "aws_cloudwatch_metric_alarm" "eop_elb_500_errors" {
+  alarm_name          = "eop-elb-500-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  threshold           = "1"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  dimensions = {
+    LoadBalancer = replace(data.aws_arn.eop_alb_arn.resource, "loadbalancer/", "") # Convert "loadbalancer/app/AAA/BBB" -> "app/AAA/BBB" to match the name expected by cloudwatch
+  }
+
+  period             = "900"
+  statistic          = "Sum"
+  alarm_description  = "This monitors 500 errors being returned from the EOP API's."
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = var.alarms_sns_topic_arn
+}

--- a/modules/eop-monitoring/main.tf
+++ b/modules/eop-monitoring/main.tf
@@ -1,7 +1,15 @@
+locals {
+  manager_service_name    = "eop-manager"
+  tileserver_service_name = "eop-tileserver"
+
+  manager_log_group_name    = "/${var.account_name}/ecs/${local.manager_service_name}"
+  tileserver_log_group_name = "/${var.account_name}/ecs/${local.tileserver_service_name}"
+}
+
 resource "aws_cloudwatch_log_metric_filter" "manager_log_errors" {
   name           = "Manager Log Error Messages"
   pattern        = "\" ERROR \""
-  log_group_name = var.eop_manager_log_group_name
+  log_group_name = local.manager_log_group_name
 
   metric_transformation {
     name          = "ErrorMessageEventCount"
@@ -13,7 +21,7 @@ resource "aws_cloudwatch_log_metric_filter" "manager_log_errors" {
 
 resource "aws_cloudwatch_metric_alarm" "manager_log_errors_alarm" {
   alarm_name          = "eop-manager-log-errors"
-  comparison_operator = "GreaterThanThreshold"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   threshold           = "1"
   namespace           = "EOP"
@@ -30,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "manager_log_errors_alarm" {
 resource "aws_cloudwatch_log_metric_filter" "manager_log_warnings" {
   name           = "Manager Log Warning Messages"
   pattern        = "\" WARN \""
-  log_group_name = var.eop_manager_log_group_name
+  log_group_name = local.manager_log_group_name
 
   metric_transformation {
     name          = "WarningMessageEventCount"
@@ -42,7 +50,7 @@ resource "aws_cloudwatch_log_metric_filter" "manager_log_warnings" {
 
 resource "aws_cloudwatch_metric_alarm" "manager_log_warnings_alarm" {
   alarm_name          = "eop-manager-log-warnings"
-  comparison_operator = "GreaterThanThreshold"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   threshold           = "1"
   namespace           = "EOP"
@@ -62,7 +70,7 @@ data "aws_arn" "eop_alb_arn" {
 
 resource "aws_cloudwatch_metric_alarm" "eop_elb_500_errors" {
   alarm_name          = "eop-elb-500-errors"
-  comparison_operator = "GreaterThanThreshold"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   threshold           = "1"
   namespace           = "AWS/ApplicationELB"
@@ -77,4 +85,156 @@ resource "aws_cloudwatch_metric_alarm" "eop_elb_500_errors" {
   treat_missing_data = "notBreaching"
 
   alarm_actions = var.alarms_sns_topic_arn
+}
+
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "eop"
+
+  dashboard_body = jsonencode({
+    start = "-PT3H"
+    widgets = [
+      {
+        height = 4,
+        width  = 24,
+        y      = 0,
+        x      = 0,
+        type   = "alarm",
+        properties = {
+          title = "Alarm Status"
+          alarms = [
+            aws_cloudwatch_metric_alarm.manager_log_errors_alarm.arn,
+            aws_cloudwatch_metric_alarm.manager_log_warnings_alarm.arn,
+            aws_cloudwatch_metric_alarm.eop_elb_500_errors.arn,
+            # The Gruntworks modules don't expose these ARNs as outputs. Easier to build them here than get them added as outputs.
+            "arn:aws:cloudwatch:${var.aws_region}:${var.account_id}:alarm:services-${var.account_name}-eop-tileserver-high-memory-utilization",
+            "arn:aws:cloudwatch:${var.aws_region}:${var.account_id}:alarm:services-${var.account_name}-eop-tileserver-high-cpu-utilization",
+            "arn:aws:cloudwatch:${var.aws_region}:${var.account_id}:alarm:services-${var.account_name}-eop-manager-high-memory-utilization",
+            "arn:aws:cloudwatch:${var.aws_region}:${var.account_id}:alarm:services-${var.account_name}-eop-manager-high-cpu-utilization",
+            "arn:aws:cloudwatch:${var.aws_region}:${var.account_id}:alarm:aurora-${var.account_name}-0-high-cpu-utilization",
+            "arn:aws:cloudwatch:${var.aws_region}:${var.account_id}:alarm:aurora-${var.account_name}-0-too-many-db-connections"
+          ]
+        }
+      },
+      {
+        height = 6,
+        width  = 24,
+        y      = 4,
+        x      = 0,
+        type   = "metric",
+        properties = {
+          metrics = [
+            [
+              "ECS/ContainerInsights",
+              "RunningTaskCount",
+              "ServiceName",
+              local.manager_service_name,
+              "ClusterName",
+              var.ecs_cluster_name,
+              {
+                label = "Manager Tasks"
+              }
+            ],
+            [
+              "...",
+              local.tileserver_service_name,
+              ".",
+              ".",
+              {
+                label = "Tile Server Tasks"
+              }
+            ]
+          ],
+          sparkline = true,
+          view      = "singleValue",
+          region    = var.aws_region,
+          title     = "Running Containers",
+          stat      = "Average",
+          period    = 300
+        }
+      },
+      {
+        height = 6,
+        width  = 6,
+        y      = 10,
+        x      = 0,
+        type   = "metric",
+        properties = {
+          metrics = [
+            ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", replace(data.aws_arn.eop_alb_arn.resource, "loadbalancer/", "")]
+          ],
+          view    = "timeSeries",
+          stacked = false,
+          region  = var.aws_region,
+          period  = 300,
+          title   = "API Request Count",
+          stat    = "SampleCount"
+        }
+      },
+      {
+        height = 6,
+        width  = 6,
+        y      = 10,
+        x      = 6,
+        type   = "metric",
+        properties = {
+          metrics = [
+            ["AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", replace(data.aws_arn.eop_alb_arn.resource, "loadbalancer/", "")]
+          ],
+          view    = "timeSeries",
+          stacked = false,
+          region  = var.aws_region,
+          period  = 300,
+          title   = "API 5XX Count",
+          stat    = "SampleCount"
+        }
+      },
+      {
+        height = 6,
+        width  = 6,
+        y      = 10,
+        x      = 12,
+        type   = "metric",
+        properties = {
+          metrics = [
+            ["AWS/ApplicationELB", "HTTPCode_Target_4XX_Count", "LoadBalancer", replace(data.aws_arn.eop_alb_arn.resource, "loadbalancer/", "")]
+          ],
+          view    = "timeSeries",
+          stacked = false,
+          region  = var.aws_region,
+          period  = 300,
+          title   = "API 4XX Count",
+          stat    = "SampleCount"
+        }
+      },
+      {
+        height = 6,
+        width  = 24,
+        y      = 16,
+        x      = 0,
+        type   = "log",
+        properties = {
+          query   = "SOURCE '${local.manager_log_group_name}' | fields @message\n| sort @timestamp desc\n| limit 50",
+          region  = var.aws_region,
+          stacked = false,
+          view    = "table",
+          title   = "Latest Manager Logs"
+        }
+      },
+      {
+        height = 6,
+        width  = 24,
+        y      = 22,
+        x      = 0,
+        type   = "log",
+        properties = {
+          query   = "SOURCE '${local.tileserver_log_group_name}' | fields @message\n| sort @timestamp desc\n| limit 50",
+          region  = var.aws_region,
+          stacked = false,
+          view    = "table",
+          title   = "Tile Server Logs"
+        }
+      },
+
+    ]
+  })
 }

--- a/modules/eop-monitoring/variables.tf
+++ b/modules/eop-monitoring/variables.tf
@@ -1,15 +1,30 @@
+variable "account_name" {
+  description = "The name of the account this is being created in. e.g eopdev"
+  type        = string
+}
+
+variable "account_id" {
+  description = "The id of the account this is being created in. e.g 111222333"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "The AWS region in which all resources will be created"
+  type        = string
+}
+
+variable "ecs_cluster_name" {
+  description = "The name of the ECS cluster"
+  type        = string
+}
+
 variable "alarms_sns_topic_arn" {
-  description = "The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications."
+  description = "The ARNs of SNS topics where CloudWatch alarms should send notifications."
   type        = list(string)
   default     = []
 }
 
 variable "eop_alb_arn" {
   description = "The name for the EOP Manager ELB."
-  type        = string
-}
-
-variable "eop_manager_log_group_name" {
-  description = "The log group name for the EOP Manager Service."
   type        = string
 }

--- a/modules/eop-monitoring/variables.tf
+++ b/modules/eop-monitoring/variables.tf
@@ -1,0 +1,15 @@
+variable "alarms_sns_topic_arn" {
+  description = "The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications."
+  type        = list(string)
+  default     = []
+}
+
+variable "eop_alb_arn" {
+  description = "The name for the EOP Manager ELB."
+  type        = string
+}
+
+variable "eop_manager_log_group_name" {
+  description = "The log group name for the EOP Manager Service."
+  type        = string
+}


### PR DESCRIPTION
**This PR adds**
* Metrics/Alerts for ERROR / WARN messages in the EOP Manager log file
* A Dashboard for overall health of the EOP system

**Future work (or should it be done now??)**
* Wanted to add some metric that would show the application being used. But there isn't an obvious way to do that (number of times the `manifest` file is loaded might be good)


Can be seen in Dev: 
https://ap-southeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-2#dashboards:name=eop;accountId=657968434173;region=ap-southeast-2
