### PR TITLE
Setup module for config of secrets meta-data

### DIFF
--- a/_envcommon/secrets/secrets.hcl
+++ b/_envcommon/secrets/secrets.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "../../../..//modules/eop-secrets"
+}

--- a/_envcommon/services/ecs-eop-ingest-api.hcl
+++ b/_envcommon/services/ecs-eop-ingest-api.hcl
@@ -2,6 +2,16 @@ terraform {
   source = "${local.source_base_url}?ref=v0.100.0"
 }
 
+dependency "eop_secrets" {
+  config_path = "${get_terragrunt_dir()}/../../secrets"
+  mock_outputs = {
+    ingest_api_kafka_credentials_arn = "secret_arn"
+    ingest_api_config_arn            = "secret_arn"
+    ingest_api_users_arn             = "secret_arn"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
 dependency "vpc" {
   config_path = "${get_terragrunt_dir()}/../../networking/vpc"
 
@@ -81,11 +91,8 @@ locals {
   # environment.
   container_image = "898449181946.dkr.ecr.ap-southeast-2.amazonaws.com/eop-ingest-api"
 
-  module_config                   = read_terragrunt_config("module_config.hcl")
-  config_secrets_manager_arn      = local.module_config.locals.config_secrets_manager_arn
-  users_secrets_manager_arn       = local.module_config.locals.users_secrets_manager_arn
-  kafka_creds_secrets_manager_arn = local.module_config.locals.kafka_creds_secrets_manager_arn
-  container_image_tag             = local.module_config.locals.container_image_tag
+  module_config       = read_terragrunt_config("module_config.hcl")
+  container_image_tag = local.module_config.locals.container_image_tag
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -217,27 +224,27 @@ inputs = {
       secrets = [
         {
           name : "CONFIG_KEYSTORE_CONTENT",
-          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_KEYSTORE_CONTENT::"
+          valueFrom : "${dependency.eop_secrets.outputs.ingest_api_config_arn}:CONFIG_KEYSTORE_CONTENT::"
         },
         {
           name : "CONFIG_KEYSTORE_PASSWORD",
-          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_KEYSTORE_PASSWORD::"
+          valueFrom : "${dependency.eop_secrets.outputs.ingest_api_config_arn}:CONFIG_KEYSTORE_PASSWORD::"
         },
         {
           name : "CONFIG_KEYSTORE_KEY",
-          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_KEYSTORE_KEY::"
+          valueFrom : "${dependency.eop_secrets.outputs.ingest_api_config_arn}:CONFIG_KEYSTORE_KEY::"
         },
         {
           name : "SPRING_APPLICATION_JSON",
-          valueFrom : local.users_secrets_manager_arn
+          valueFrom : dependency.eop_secrets.outputs.ingest_api_users_arn
         },
         {
           name : "KAFKA_SASL_USERNAME",
-          valueFrom : "${local.kafka_creds_secrets_manager_arn}:username::"
+          valueFrom : "${dependency.eop_secrets.outputs.ingest_api_kafka_credentials_arn}:username::"
         },
         {
           name : "KAFKA_SASL_PASSWORD",
-          valueFrom : "${local.kafka_creds_secrets_manager_arn}:password::"
+          valueFrom : "${dependency.eop_secrets.outputs.ingest_api_kafka_credentials_arn}:password::"
         },
       ]
 
@@ -263,8 +270,8 @@ inputs = {
   ]
 
   secrets_manager_arns = [
-    local.config_secrets_manager_arn,
-    local.users_secrets_manager_arn,
-    local.kafka_creds_secrets_manager_arn,
+    dependency.eop_secrets.outputs.ingest_api_kafka_credentials_arn,
+    dependency.eop_secrets.outputs.ingest_api_config_arn,
+    dependency.eop_secrets.outputs.ingest_api_users_arn,
   ]
 }

--- a/_envcommon/services/ecs-eop-ingest-api.hcl
+++ b/_envcommon/services/ecs-eop-ingest-api.hcl
@@ -240,11 +240,11 @@ inputs = {
         },
         {
           name : "KAFKA_SASL_USERNAME",
-          valueFrom : "${dependency.eop_secrets.outputs.ingest_api_kafka_credentials_arn}:username::"
+          valueFrom : "${dependency.eop_secrets.outputs.kafka_client_credentials_arn}:username::"
         },
         {
           name : "KAFKA_SASL_PASSWORD",
-          valueFrom : "${dependency.eop_secrets.outputs.ingest_api_kafka_credentials_arn}:password::"
+          valueFrom : "${dependency.eop_secrets.outputs.kafka_client_credentials_arn}:password::"
         },
       ]
 
@@ -270,7 +270,7 @@ inputs = {
   ]
 
   secrets_manager_arns = [
-    dependency.eop_secrets.outputs.ingest_api_kafka_credentials_arn,
+    dependency.eop_secrets.outputs.kafka_client_credentials_arn,
     dependency.eop_secrets.outputs.ingest_api_config_arn,
     dependency.eop_secrets.outputs.ingest_api_users_arn,
   ]

--- a/_envcommon/services/ecs-eop-manager.hcl
+++ b/_envcommon/services/ecs-eop-manager.hcl
@@ -2,6 +2,16 @@ terraform {
   source = "${local.source_base_url}?ref=v0.100.0"
 }
 
+dependency "eop_secrets" {
+  config_path = "${get_terragrunt_dir()}/../../secrets"
+  mock_outputs = {
+    ingest_api_kafka_credentials_arn = "secret_arn"
+    ingest_api_config_arn            = "secret_arn"
+    ingest_api_users_arn             = "secret_arn"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
 dependency "vpc" {
   config_path = "${get_terragrunt_dir()}/../../networking/vpc"
 
@@ -82,9 +92,8 @@ locals {
   # environment.
   container_image = "898449181946.dkr.ecr.ap-southeast-2.amazonaws.com/eop-manager"
 
-  module_config              = read_terragrunt_config("module_config.hcl")
-  config_secrets_manager_arn = local.module_config.locals.config_secrets_manager_arn
-  container_image_tag        = local.module_config.locals.container_image_tag
+  module_config       = read_terragrunt_config("module_config.hcl")
+  container_image_tag = local.module_config.locals.container_image_tag
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -221,35 +230,35 @@ inputs = {
       secrets = [
         {
           name : "CONFIG_DATABASE_USERNAME",
-          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_DATABASE_USERNAME::"
+          valueFrom : "${dependency.eop_secrets.outputs.manager_config_arn}:CONFIG_DATABASE_USERNAME::"
         },
         {
           name : "CONFIG_DATABASE_PASSWORD",
-          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_DATABASE_PASSWORD::"
+          valueFrom : "${dependency.eop_secrets.outputs.manager_config_arn}:CONFIG_DATABASE_PASSWORD::"
         },
         {
           name : "CONFIG_DATABASE_MIGRATIONS_USERNAME",
-          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_DATABASE_MIGRATIONS_USERNAME::"
+          valueFrom : "${dependency.eop_secrets.outputs.manager_config_arn}:CONFIG_DATABASE_MIGRATIONS_USERNAME::"
         },
         {
           name : "CONFIG_DATABASE_MIGRATIONS_PASSWORD",
-          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_DATABASE_MIGRATIONS_PASSWORD::"
+          valueFrom : "${dependency.eop_secrets.outputs.manager_config_arn}:CONFIG_DATABASE_MIGRATIONS_PASSWORD::"
         },
         {
           name : "CONFIG_DATABASE_NAME",
-          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_DATABASE_NAME::"
+          valueFrom : "${dependency.eop_secrets.outputs.manager_config_arn}:CONFIG_DATABASE_NAME::"
         },
         {
           name : "CONFIG_KEYSTORE_CONTENT",
-          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_KEYSTORE_CONTENT::"
+          valueFrom : "${dependency.eop_secrets.outputs.manager_config_arn}:CONFIG_KEYSTORE_CONTENT::"
         },
         {
           name : "CONFIG_KEYSTORE_PASSWORD",
-          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_KEYSTORE_PASSWORD::"
+          valueFrom : "${dependency.eop_secrets.outputs.manager_config_arn}:CONFIG_KEYSTORE_PASSWORD::"
         },
         {
           name : "CONFIG_KEYSTORE_KEY",
-          valueFrom : "${local.config_secrets_manager_arn}:CONFIG_KEYSTORE_KEY::"
+          valueFrom : "${dependency.eop_secrets.outputs.manager_config_arn}:CONFIG_KEYSTORE_KEY::"
         },
       ]
 
@@ -275,6 +284,6 @@ inputs = {
   ]
 
   secrets_manager_arns = [
-    local.config_secrets_manager_arn,
+    dependency.eop_secrets.outputs.manager_config_arn,
   ]
 }

--- a/eopdev/ap-southeast-2/eopdev/data-stores/aurora/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/eopdev/data-stores/aurora/terragrunt.hcl
@@ -14,13 +14,4 @@ include "envcommon" {
 # Module parameters to pass in. Note that these parameters are environment specific.
 # ---------------------------------------------------------------------------------------------------------------------
 inputs = {
-  name = "aurora-eopdev"
-
-  # The DB config secret contains the following data:
-  # - DB engine (e.g. postgres, mysql, etc)
-  # - Default database name
-  # - Port
-  # - Username and password
-  # Alternatively, these can be specified as individual inputs.
-  db_config_secrets_manager_id = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:RDSDBConfig-wHo5DD"
 }

--- a/eopdev/ap-southeast-2/eopdev/secrets/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/eopdev/secrets/terragrunt.hcl
@@ -1,0 +1,10 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/secrets/secrets.hcl"
+}
+
+inputs = {
+}

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
@@ -1,7 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  config_secrets_manager_arn      = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIConfig-Sd0J4T"
-  users_secrets_manager_arn       = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPIngestAPIUsers-OGblpw"
-  kafka_creds_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:AmazonMSK_EOPIngestAPIKafkaCredentials-kndW0a"
-  container_image_tag             = "e2dbcfb8936e8ec1e484ed54ab6ed965d43a0b4d"
+  container_image_tag = "e2dbcfb8936e8ec1e484ed54ab6ed965d43a0b4d"
 }

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-manager/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-manager/module_config.hcl
@@ -1,6 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  config_secrets_manager_arn      = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPManagerConfig-cWXx3Q"
-  kafka_creds_secrets_manager_arn = "arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:AmazonMSK_EOPIngestAPIKafkaCredentials-kndW0a"
-  container_image_tag             = "90d4e9a5ff0f92bc2965b84d297ae82f923b9432"
+  container_image_tag = "90d4e9a5ff0f92bc2965b84d297ae82f923b9432"
 }

--- a/eopprod/ap-southeast-2/eopprod/data-stores/aurora/terragrunt.hcl
+++ b/eopprod/ap-southeast-2/eopprod/data-stores/aurora/terragrunt.hcl
@@ -14,12 +14,4 @@ include "envcommon" {
 # Module parameters to pass in. Note that these parameters are environment specific.
 # ---------------------------------------------------------------------------------------------------------------------
 inputs = {
-
-  # The DB config secret contains the following data:
-  # - DB engine (e.g. postgres, mysql, etc)
-  # - Default database name
-  # - Port
-  # - Username and password
-  # Alternatively, these can be specified as individual inputs.
-  db_config_secrets_manager_id = "arn:aws:secretsmanager:ap-southeast-2:422253851608:secret:RDSDBConfig-ZgtELd"
 }

--- a/eopprod/ap-southeast-2/eopprod/secrets/terragrunt.hcl
+++ b/eopprod/ap-southeast-2/eopprod/secrets/terragrunt.hcl
@@ -1,0 +1,10 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/secrets/secrets.hcl"
+}
+
+inputs = {
+}

--- a/eopstage/ap-southeast-2/eopstage/data-stores/aurora/terragrunt.hcl
+++ b/eopstage/ap-southeast-2/eopstage/data-stores/aurora/terragrunt.hcl
@@ -14,12 +14,4 @@ include "envcommon" {
 # Module parameters to pass in. Note that these parameters are environment specific.
 # ---------------------------------------------------------------------------------------------------------------------
 inputs = {
-
-  # The DB config secret contains the following data:
-  # - DB engine (e.g. postgres, mysql, etc)
-  # - Default database name
-  # - Port
-  # - Username and password
-  # Alternatively, these can be specified as individual inputs.
-  db_config_secrets_manager_id = "arn:aws:secretsmanager:ap-southeast-2:564180615104:secret:RDSDBConfig-roeweY"
 }

--- a/eopstage/ap-southeast-2/eopstage/secrets/terragrunt.hcl
+++ b/eopstage/ap-southeast-2/eopstage/secrets/terragrunt.hcl
@@ -1,0 +1,10 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/secrets/secrets.hcl"
+}
+
+inputs = {
+}

--- a/modules/eop-secrets/README.md
+++ b/modules/eop-secrets/README.md
@@ -1,14 +1,15 @@
 # Description
 
-> This module must be applied and secrets manager values populated before terraform creates modules that use these secrets.
+> This module must be applied and secrets manager values populated before terraform creates modules that use these
+> secrets.
 
 This module contains the configuration of the meta-data for secrets used in EOP.
 This explicitly doesn't contain secret values, and those need to be created manually.
-What this does mean is
-that dependencies between modules and secrets can be represented in code rather than via hard-coded strings.
+What this does mean is that dependencies between modules and secrets can be represented in code rather than via
+hard-coded strings.
 
-This is a bit of an antipattern that this module will contain secrets' definitions from many modules.
-However it is ok at the moment to prevent needing many small modules to keep the secrets separated.
+This could be thought of an antipattern that this module contains secrets' definitions from many potentially
+unrelated modules. However, we're accepting this vs having to create many small modules for config.
 
 
  

--- a/modules/eop-secrets/README.md
+++ b/modules/eop-secrets/README.md
@@ -1,0 +1,14 @@
+# Description
+
+> This module must be applied and secrets manager values populated before terraform creates modules that use these secrets.
+
+This module contains the configuration of the meta-data for secrets used in EOP.
+This explicitly doesn't contain secret values, and those need to be created manually.
+What this does mean is
+that dependencies between modules and secrets can be represented in code rather than via hard-coded strings.
+
+This is a bit of an antipattern that this module will contain secrets' definitions from many modules.
+However it is ok at the moment to prevent needing many small modules to keep the secrets separated.
+
+
+ 

--- a/modules/eop-secrets/main.tf
+++ b/modules/eop-secrets/main.tf
@@ -2,6 +2,10 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 # Aurora Postgres
+resource "aws_secretsmanager_secret" "aurora_rds_config" {
+  name        = "RDSDBConfig"
+  description = "Configuration for the RDS database instance."
+}
 
 # Kafka
 ## SASL config secrets for Kafka require a KMS key that is not the default
@@ -70,18 +74,28 @@ resource "aws_kms_key_policy" "kafka_sasl_credentials_key_policy" {
   })
 }
 
-# EOP Manager
-
-# Ingest API
-resource "aws_secretsmanager_secret" "ingest_api_kafka_credentials" {
-  name        = "AmazonMSK_EOPIngestAPIKafkaCredentials"
-  description = "SASL/SCRAM Credentials used by the IngestAPI to connect to Kafka"
+resource "aws_secretsmanager_secret" "kafka_client_credentials" {
+  name        = "AmazonMSK_KafkaClientCredentials"
+  description = "SASL/SCRAM Credentials used by the client applications to connect to Kafka"
   kms_key_id  = aws_kms_key.kafka_sasl_credentials_key.id
 }
 
+# EOP Manager
+resource "aws_secretsmanager_secret" "manager_config" {
+  name        = "EOPManagerConfig"
+  description = "Sensitive configuration details for the Manager Application"
+}
+
+# Tile Server
+resource "aws_secretsmanager_secret" "tileserver_config" {
+  name        = "EOPTileServerConfig"
+  description = "Sensitive configuration details for the TileServer service"
+}
+
+# Ingest API
 resource "aws_secretsmanager_secret" "ingest_api_config" {
   name        = "EOPIngestAPIConfig"
-  description = "Configuration for the EOP Ingest API Service"
+  description = "Sensitive configuration details for the Ingest API application"
 }
 
 resource "aws_secretsmanager_secret" "ingest_api_users" {

--- a/modules/eop-secrets/main.tf
+++ b/modules/eop-secrets/main.tf
@@ -1,0 +1,90 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# Aurora Postgres
+
+# Kafka
+## SASL config secrets for Kafka require a KMS key that is not the default
+resource "aws_kms_key" "kafka_sasl_credentials_key" {
+  description = "Used to encrypt Secrets Manager Secrets containing Kafka SASL/SCRAM credentials"
+}
+
+resource "aws_kms_alias" "kafka_sasl_credentials_key_alias" {
+  target_key_id = aws_kms_key.kafka_sasl_credentials_key.key_id
+  name          = "alias/eop-secretsmanager-kafka-sasl-creds"
+}
+
+resource "aws_kms_key_policy" "kafka_sasl_credentials_key_policy" {
+  key_id = aws_kms_key.kafka_sasl_credentials_key.key_id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "Enable IAM User Permissions"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Resource = "*"
+        Action   = "kms:*"
+        Effect   = "Allow"
+      },
+      {
+        Sid = "Allow access through AWS Secrets Manager for all principals in the account that are authorized to use AWS Secrets Manager"
+        Principal = {
+          AWS = "*"
+        }
+        Condition = {
+          StringEquals = {
+            "kms:CallerAccount" = data.aws_caller_identity.current.id
+            "kms:ViaService"    = "secretsmanager.${data.aws_region.current.name}.amazonaws.com"
+          }
+        }
+        Resource = "*"
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:CreateGrant",
+          "kms:DescribeKey"
+        ]
+        Effect = "Allow"
+      },
+      {
+        Sid = "Allow access through AWS Secrets Manager for all principals in the account that are authorized to use AWS Secrets Manager"
+        Principal = {
+          AWS = "*"
+        }
+        Condition = {
+          StringEquals = {
+            "kms:CallerAccount" = data.aws_caller_identity.current.id
+          }
+          StringLike = {
+            "kms:ViaService" = "secretsmanager.*.amazonaws.com"
+          }
+        }
+        Resource = "*"
+        Action   = "kms:GenerateDataKey*"
+        Effect   = "Allow"
+      }
+    ]
+  })
+}
+
+# EOP Manager
+
+# Ingest API
+resource "aws_secretsmanager_secret" "ingest_api_kafka_credentials" {
+  name        = "AmazonMSK_EOPIngestAPIKafkaCredentials"
+  description = "SASL/SCRAM Credentials used by the IngestAPI to connect to Kafka"
+  kms_key_id  = aws_kms_key.kafka_sasl_credentials_key.id
+}
+
+resource "aws_secretsmanager_secret" "ingest_api_config" {
+  name        = "EOPIngestAPIConfig"
+  description = "Configuration for the EOP Ingest API Service"
+}
+
+resource "aws_secretsmanager_secret" "ingest_api_users" {
+  name        = "EOPIngestAPIUsers"
+  description = "API users that can access the Ingest API"
+}

--- a/modules/eop-secrets/outputs.tf
+++ b/modules/eop-secrets/outputs.tf
@@ -1,0 +1,14 @@
+output "ingest_api_kafka_credentials_arn" {
+  description = "The ARN for the ingest API Kafka Credentials secret"
+  value       = aws_secretsmanager_secret.ingest_api_kafka_credentials.arn
+}
+
+output "ingest_api_config_arn" {
+  description = "The ARN for the ingest API Config secret"
+  value       = aws_secretsmanager_secret.ingest_api_config.arn
+}
+
+output "ingest_api_users_arn" {
+  description = "The ARN for the ingest API users secret"
+  value       = aws_secretsmanager_secret.ingest_api_users.arn
+}

--- a/modules/eop-secrets/outputs.tf
+++ b/modules/eop-secrets/outputs.tf
@@ -1,14 +1,33 @@
-output "ingest_api_kafka_credentials_arn" {
-  description = "The ARN for the ingest API Kafka Credentials secret"
-  value       = aws_secretsmanager_secret.ingest_api_kafka_credentials.arn
+# Aurora Postgres
+output "aurora_rds_config_arn" {
+  description = "The ARN for the ingest Aurora RDS Config secret"
+  value       = aws_secretsmanager_secret.aurora_rds_config.arn
+}
+
+# Manager
+output "manager_config_arn" {
+  description = "The ARN for the Manager Config secret"
+  value       = aws_secretsmanager_secret.manager_config.arn
+}
+
+# Tile Server
+output "tileserver_config_arn" {
+  description = "The ARN for the Tileserver Config secret"
+  value       = aws_secretsmanager_secret.tileserver_config.arn
+}
+
+# Ingest API
+output "kafka_client_credentials_arn" {
+  description = "The ARN for the Ingest API Kafka Credentials secret"
+  value       = aws_secretsmanager_secret.kafka_client_credentials.arn
 }
 
 output "ingest_api_config_arn" {
-  description = "The ARN for the ingest API Config secret"
+  description = "The ARN for the Ingest API Config secret"
   value       = aws_secretsmanager_secret.ingest_api_config.arn
 }
 
 output "ingest_api_users_arn" {
-  description = "The ARN for the ingest API users secret"
+  description = "The ARN for the Ingest API users secret"
   value       = aws_secretsmanager_secret.ingest_api_users.arn
 }


### PR DESCRIPTION
- Moved the config of all secrets into a module for them (secret values must be manually applied)
- Configured other modules to use those secrets
- This will create the secrets needed for the Kafka / Ingest API.

This needs to be merged, and secrets manually added before before #85 

For the existing secret values, they need to be manually imported into TF state before this is merged.
e.g.
`aws-vault exec eopdev -- terragrunt import aws_secretsmanager_secret.manager_config arn:aws:secretsmanager:ap-southeast-2:657968434173:secret:EOPManagerConfig-cWXx3Q`

