### PR TITLE
Update Kafka version

### DIFF
--- a/_envcommon/data-stores/msk.hcl
+++ b/_envcommon/data-stores/msk.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.10.1"
+  source = "${local.source_base_url}?ref=v0.12.2"
 }
 
 dependency "eop_secrets" {
@@ -40,7 +40,7 @@ locals {
 inputs = {
   cluster_name                           = "kafka-${lower(local.account_name)}"
   cluster_size                           = 3
-  kafka_version                          = "3.3.1"
+  kafka_version                          = "3.4.0"
   instance_type                          = "kafka.t3.small"
   vpc_id                                 = dependency.vpc.outputs.vpc_id
   subnet_ids                             = dependency.vpc.outputs.private_persistence_subnet_ids

--- a/accounts.json
+++ b/accounts.json
@@ -1,31 +1,31 @@
 {
   "eopdev": {
-    "deploy_order": 0,
+    "deploy_order": 4,
     "id": "657968434173",
     "root_user_email": ""
   },
   "eopprod": {
-    "deploy_order": 0,
+    "deploy_order": 6,
     "id": "422253851608",
     "root_user_email": ""
   },
   "eopstage": {
-    "deploy_order": 0,
+    "deploy_order": 5,
     "id": "564180615104",
     "root_user_email": ""
   },
   "logs": {
-    "deploy_order": 0,
+    "deploy_order": 1,
     "id": "972859489186",
     "root_user_email": ""
   },
   "security": {
-    "deploy_order": 0,
+    "deploy_order": 2,
     "id": "063810897000",
     "root_user_email": ""
   },
   "shared": {
-    "deploy_order": 0,
+    "deploy_order": 3,
     "id": "898449181946",
     "root_user_email": ""
   }

--- a/eopprod/ap-southeast-2/eopprod/data-stores/kafka/terragrunt.hcl
+++ b/eopprod/ap-southeast-2/eopprod/data-stores/kafka/terragrunt.hcl
@@ -11,4 +11,5 @@ include "envcommon" {
 }
 
 inputs = {
+  kafka_version = "3.3.1"
 }


### PR DESCRIPTION
Upgrade to latest Kafka version

Note this requires some manual faff for deployment as the Gruntworks / Terraform module tries to remove a component while it is still in use. 

* Clone the "Cluster Configuration" with a name like `eop-temp` and attach it to the cluster
* Deploy - Terraform will have removed and replaced the existing cluster configuration and attached the replacement to the cluster
* Remove the temp cluster config

Also when deploying to dev, had a issue where the upgrade took so long that the access token terraform was using for AWS timed out. This required some manual tidy up



