### PR TITLE
Add ability for apps to produce cloudwatch metrics

### DIFF
--- a/_envcommon/services/ecs-eop-hilltop-crawler.hcl
+++ b/_envcommon/services/ecs-eop-hilltop-crawler.hcl
@@ -134,6 +134,15 @@ inputs = {
 
   custom_iam_policy_prefix = local.service_name
 
+  iam_policy = {
+    CloudWatchMetrics = {
+      actions   = ["cloudwatch:PutMetricData"]
+      resources = ["*"]
+      effect    = "Allow"
+    },
+  }
+
+
   # --------------------------------------------------------------------------------------------------------------------
   # ALB configuration
   # We configure Target Groups for the ECS service so that the ALBs can route to the ECS tasks that are deployed on each

--- a/_envcommon/services/ecs-eop-ingest-api.hcl
+++ b/_envcommon/services/ecs-eop-ingest-api.hcl
@@ -144,6 +144,14 @@ inputs = {
 
   custom_iam_policy_prefix = local.service_name
 
+  iam_policy = {
+    CloudWatchMetrics = {
+      actions   = ["cloudwatch:PutMetricData"]
+      resources = ["*"]
+      effect    = "Allow"
+    },
+  }
+
   # --------------------------------------------------------------------------------------------------------------------
   # ALB configuration
   # We configure Target Groups for the ECS service so that the ALBs can route to the ECS tasks that are deployed on each

--- a/_envcommon/services/ecs-eop-manager-hilltop-consumer.hcl
+++ b/_envcommon/services/ecs-eop-manager-hilltop-consumer.hcl
@@ -154,6 +154,14 @@ inputs = {
 
   custom_iam_policy_prefix = local.service_name
 
+  iam_policy = {
+    CloudWatchMetrics = {
+      actions   = ["cloudwatch:PutMetricData"]
+      resources = ["*"]
+      effect    = "Allow"
+    },
+  }
+
   # --------------------------------------------------------------------------------------------------------------------
   # ALB configuration
   # We configure Target Groups for the ECS service so that the ALBs can route to the ECS tasks that are deployed on each

--- a/_envcommon/services/ecs-eop-manager.hcl
+++ b/_envcommon/services/ecs-eop-manager.hcl
@@ -154,6 +154,14 @@ inputs = {
 
   custom_iam_policy_prefix = local.service_name
 
+  iam_policy = {
+    CloudWatchMetrics = {
+      actions   = ["cloudwatch:PutMetricData"]
+      resources = ["*"]
+      effect    = "Allow"
+    },
+  }
+
   # --------------------------------------------------------------------------------------------------------------------
   # ALB configuration
   # We configure Target Groups for the ECS service so that the ALBs can route to the ECS tasks that are deployed on each


### PR DESCRIPTION
This is to allow the Java application to write Cloudwatch Metrics. 

Was using this while debugging some issues with the Hilltop Crawler / Observations consumer.

See next PR from the EOP repo for deploying the changes that write metrics. 
