### PR TITLE
Fixup issue with not forcing the plan limits viewer to redirect to HTTPS

### DIFF
--- a/_envcommon/services/static-site-eop-plan-limits.hcl
+++ b/_envcommon/services/static-site-eop-plan-limits.hcl
@@ -44,6 +44,7 @@ inputs = {
   acm_certificate_domain_name             = "${local.account_vars.locals.domain_name.name}"
   security_header_content_security_policy = "default-src 'self'; base-uri 'self'; block-all-mixed-content; font-src 'self' https: data:; form-action 'self'; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src 'self' blob: https://api.mapbox.com/; script-src-attr 'none'; style-src 'self' https: 'unsafe-inline'; connect-src 'self' https://api.mapbox.com/ https://basemaps.linz.govt.nz/ https://data.${local.account_vars.locals.domain_name.name}/ https://tiles.${local.account_vars.locals.domain_name.name}/; upgrade-insecure-requests"
   use_cloudfront_arn_for_bucket_policy    = true
+  viewer_protocol_policy                  = "redirect-to-https"
 
   error_responses = {
     404 = {


### PR DESCRIPTION
We must have wrongly assumed the default was the other way. And some strange behavior (assuming to be because of HSTS) is making it work most of the time anyway.

But doing `curl` for the site or a clean profile in chrome will let you get there on http only