### PR TITLE
Budget Alerts 1 - Adding in KMS Key for encrypting data in the SNS Topic for Budget Alerts

### DIFF
--- a/_envcommon/landingzone/account-baseline-app-base.hcl
+++ b/_envcommon/landingzone/account-baseline-app-base.hcl
@@ -107,6 +107,14 @@ locals {
         actions = ["kms:Decrypt", "kms:GenerateDataKey*"]
       }]
     }
+    budget-alarm-sns-encryption = {
+      region                     = local.aws_region
+      cmk_administrator_iam_arns = ["arn:aws:iam::${local.account_id}:root"]
+      cmk_service_principals = [{
+        name    = "budgets.amazonaws.com"
+        actions = ["kms:Decrypt", "kms:GenerateDataKey*"]
+      }]
+    }
   }
 }
 


### PR DESCRIPTION
This needs to be done in two parts as TF can't plan the next part without this already existing.

Creates an encryption key used to encrypt the messages the get sent to SNS for notifications about budget alerts.


