### PR TITLE
PT2 - Create Budget Alerts

### DIFF
--- a/_envcommon/landingzone/account-baseline-app-base.hcl
+++ b/_envcommon/landingzone/account-baseline-app-base.hcl
@@ -107,6 +107,14 @@ locals {
         actions = ["kms:Decrypt", "kms:GenerateDataKey*"]
       }]
     }
+    budget-alarm-sns-encryption = {
+      region                     = local.aws_region
+      cmk_administrator_iam_arns = ["arn:aws:iam::${local.account_id}:root"]
+      cmk_service_principals = [{
+        name    = "budgets.amazonaws.com"
+        actions = ["kms:Decrypt", "kms:GenerateDataKey*"]
+      }]
+    }
   }
 }
 

--- a/_envcommon/landingzone/account-baseline-app-base.hcl
+++ b/_envcommon/landingzone/account-baseline-app-base.hcl
@@ -107,14 +107,6 @@ locals {
         actions = ["kms:Decrypt", "kms:GenerateDataKey*"]
       }]
     }
-    budget-alarm-sns-encryption = {
-      region                     = local.aws_region
-      cmk_administrator_iam_arns = ["arn:aws:iam::${local.account_id}:root"]
-      cmk_service_principals = [{
-        name    = "budgets.amazonaws.com"
-        actions = ["kms:Decrypt", "kms:GenerateDataKey*"]
-      }]
-    }
   }
 }
 

--- a/_envcommon/landingzone/budget-monitoring.hcl
+++ b/_envcommon/landingzone/budget-monitoring.hcl
@@ -2,44 +2,14 @@ terraform {
   source = "../../..//modules/budget-monitoring"
 }
 
-dependency "account_baseline" {
-  config_path = "${dirname(find_in_parent_folders("account.hcl"))}/_global/account-baseline"
-
-  mock_outputs = {
-    kms_key_arns = {
-      (local.aws_region) = {
-        "budget-alarm-sns-encryption" = "arn:aws:kms:us-east-1:111122223333:key/asdf"
-      }
-    }
-  }
-  mock_outputs_allowed_terraform_commands = ["validate", ]
-}
-
 locals {
-  # Automatically load common variables shared across all accounts
-  common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))
-
-  # Extract the name prefix for easy access
-  name_prefix = local.common_vars.locals.name_prefix
-
-  # Automatically load account-level variables
+  common_vars  = read_terragrunt_config(find_in_parent_folders("common.hcl"))
   account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
-
-  # Extract the account_name and account_role for easy access
-  account_name = local.account_vars.locals.account_name
-
-  # Automatically load region-level variables
-  region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
-
-  # Extract the region for easy access
-  aws_region = local.region_vars.locals.aws_region
 }
 
 inputs = {
   total_monthly_budget_amount      = 1250.00
   monthly_cloudwatch_budget_amount = 150
 
-  sns_topic_name        = "${local.name_prefix}-${lower(local.account_name)}-budget-alarms"
-  sns_kms_master_key_id = dependency.account_baseline.outputs.kms_key_arns[local.aws_region]["budget-alarm-sns-encryption"]
-
+  notification_email_addresses = setunion(local.account_vars.locals.budget_monitoring_notification_email_addresses, local.common_vars.locals.budget_monitoring_notification_email_addresses)
 }

--- a/_envcommon/landingzone/budget-monitoring.hcl
+++ b/_envcommon/landingzone/budget-monitoring.hcl
@@ -1,0 +1,45 @@
+terraform {
+  source = "../../..//modules/budget-monitoring"
+}
+
+dependency "account_baseline" {
+  config_path = "${dirname(find_in_parent_folders("account.hcl"))}/_global/account-baseline"
+
+  mock_outputs = {
+    kms_key_arns = {
+      (local.aws_region) = {
+        "budget-alarm-sns-encryption" = "arn:aws:kms:us-east-1:111122223333:key/asdf"
+      }
+    }
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", ]
+}
+
+locals {
+  # Automatically load common variables shared across all accounts
+  common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))
+
+  # Extract the name prefix for easy access
+  name_prefix = local.common_vars.locals.name_prefix
+
+  # Automatically load account-level variables
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract the account_name and account_role for easy access
+  account_name = local.account_vars.locals.account_name
+
+  # Automatically load region-level variables
+  region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  # Extract the region for easy access
+  aws_region = local.region_vars.locals.aws_region
+}
+
+inputs = {
+  total_monthly_budget_amount      = 1250.00
+  monthly_cloudwatch_budget_amount = 150
+
+  sns_topic_name        = "${local.name_prefix}-${lower(local.account_name)}-budget-alarms"
+  sns_kms_master_key_id = dependency.account_baseline.outputs.kms_key_arns[local.aws_region]["budget-alarm-sns-encryption"]
+
+}

--- a/common.hcl
+++ b/common.hcl
@@ -93,4 +93,6 @@ locals {
 
   # Centrally define the internal services domain name configured by the route53-private module
   internal_services_domain_name = "gwrc.aws"
+
+  budget_monitoring_notification_email_addresses = ["1c7ffc35.greaterwellington.onmicrosoft.com@au.teams.ms", "sam.gundersen@gw.govt.nz", "chris.dick@gw.govt.nz"]
 }

--- a/eopdev/_global/budget-monitoring/terragrunt.hcl
+++ b/eopdev/_global/budget-monitoring/terragrunt.hcl
@@ -1,0 +1,7 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/landingzone/budget-monitoring.hcl"
+}

--- a/eopdev/account.hcl
+++ b/eopdev/account.hcl
@@ -8,4 +8,6 @@ locals {
       created_outside_terraform = true
     }
   }
+
+  budget_monitoring_notification_email_addresses = ["eop+eopdev_budget_notifications@gw.govt.nz"]
 }

--- a/eopprod/_global/budget-monitoring/terragrunt.hcl
+++ b/eopprod/_global/budget-monitoring/terragrunt.hcl
@@ -1,0 +1,7 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/landingzone/budget-monitoring.hcl"
+}

--- a/eopprod/account.hcl
+++ b/eopprod/account.hcl
@@ -8,4 +8,5 @@ locals {
       created_outside_terraform = true
     }
   }
+  budget_monitoring_notification_email_addresses = ["eop+eopprod_budget_notifications@gw.govt.nz"]
 }

--- a/eopstage/_global/budget-monitoring/terragrunt.hcl
+++ b/eopstage/_global/budget-monitoring/terragrunt.hcl
@@ -1,0 +1,7 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/landingzone/budget-monitoring.hcl"
+}

--- a/eopstage/account.hcl
+++ b/eopstage/account.hcl
@@ -8,4 +8,5 @@ locals {
       created_outside_terraform = true
     }
   }
+  budget_monitoring_notification_email_addresses = ["eop+eopstage_budget_notifications@gw.govt.nz"]
 }

--- a/logs/_global/budget-monitoring/terragrunt.hcl
+++ b/logs/_global/budget-monitoring/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/landingzone/budget-monitoring.hcl"
+}
+
+inputs = {
+  total_monthly_budget_amount      = 100
+  monthly_cloudwatch_budget_amount = 5
+}

--- a/logs/account.hcl
+++ b/logs/account.hcl
@@ -1,6 +1,6 @@
 # Set account-wide variables
 locals {
-  account_name = "logs"
-  account_role = "logs"
-
+  account_name                                   = "logs"
+  account_role                                   = "logs"
+  budget_monitoring_notification_email_addresses = ["eop+eoplogs_budget_notifications@gw.govt.nz"]
 }

--- a/modules/budget-monitoring/main.tf
+++ b/modules/budget-monitoring/main.tf
@@ -1,0 +1,62 @@
+resource "aws_budgets_budget" "total_monthly_budget" {
+  name         = "Total Month Spend Budget"
+  budget_type  = "COST"
+  limit_amount = var.total_monthly_budget_amount
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  time_period_start = "2022-10-01_00:00"
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [module.sns_topic.topic_arn]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 80
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [module.sns_topic.topic_arn]
+  }
+}
+
+resource "aws_budgets_budget" "monthly_cloudwatch_budget" {
+  name         = "Monthly Cloudwatch Spend Budget"
+  budget_type  = "COST"
+  limit_amount = var.monthly_cloudwatch_budget_amount
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  time_period_start = "2022-10-01_00:00"
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [module.sns_topic.topic_arn]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 80
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [module.sns_topic.topic_arn]
+  }
+}
+
+module "sns_topic" {
+  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/sns-topics"
+
+  name              = var.sns_topic_name
+  kms_master_key_id = var.sns_kms_master_key_id
+
+  allow_publish_services = [
+    "budgets.amazonaws.com"
+  ]
+}

--- a/modules/budget-monitoring/main.tf
+++ b/modules/budget-monitoring/main.tf
@@ -8,19 +8,19 @@ resource "aws_budgets_budget" "total_monthly_budget" {
   time_period_start = "2022-10-01_00:00"
 
   notification {
-    comparison_operator       = "GREATER_THAN"
-    threshold                 = 100
-    threshold_type            = "PERCENTAGE"
-    notification_type         = "FORECASTED"
-    subscriber_sns_topic_arns = [module.sns_topic.topic_arn]
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = var.notification_email_addresses
   }
 
   notification {
-    comparison_operator       = "GREATER_THAN"
-    threshold                 = 80
-    threshold_type            = "PERCENTAGE"
-    notification_type         = "ACTUAL"
-    subscriber_sns_topic_arns = [module.sns_topic.topic_arn]
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = var.notification_email_addresses
   }
 }
 
@@ -34,29 +34,18 @@ resource "aws_budgets_budget" "monthly_cloudwatch_budget" {
   time_period_start = "2022-10-01_00:00"
 
   notification {
-    comparison_operator       = "GREATER_THAN"
-    threshold                 = 100
-    threshold_type            = "PERCENTAGE"
-    notification_type         = "FORECASTED"
-    subscriber_sns_topic_arns = [module.sns_topic.topic_arn]
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = var.notification_email_addresses
   }
 
   notification {
-    comparison_operator       = "GREATER_THAN"
-    threshold                 = 80
-    threshold_type            = "PERCENTAGE"
-    notification_type         = "ACTUAL"
-    subscriber_sns_topic_arns = [module.sns_topic.topic_arn]
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = var.notification_email_addresses
   }
-}
-
-module "sns_topic" {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/sns-topics"
-
-  name              = var.sns_topic_name
-  kms_master_key_id = var.sns_kms_master_key_id
-
-  allow_publish_services = [
-    "budgets.amazonaws.com"
-  ]
 }

--- a/modules/budget-monitoring/variables.tf
+++ b/modules/budget-monitoring/variables.tf
@@ -1,15 +1,11 @@
-variable "sns_topic_name" {
-  type = string
-}
-
-variable "sns_kms_master_key_id" {
-  type = string
-}
-
 variable "total_monthly_budget_amount" {
   type = number
 }
 
 variable "monthly_cloudwatch_budget_amount" {
   type = number
+}
+
+variable "notification_email_addresses" {
+  type = set(string)
 }

--- a/modules/budget-monitoring/variables.tf
+++ b/modules/budget-monitoring/variables.tf
@@ -1,0 +1,15 @@
+variable "sns_topic_name" {
+  type = string
+}
+
+variable "sns_kms_master_key_id" {
+  type = string
+}
+
+variable "total_monthly_budget_amount" {
+  type = number
+}
+
+variable "monthly_cloudwatch_budget_amount" {
+  type = number
+}

--- a/security/_global/budget-monitoring/terragrunt.hcl
+++ b/security/_global/budget-monitoring/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/landingzone/budget-monitoring.hcl"
+}
+
+inputs = {
+  total_monthly_budget_amount      = 75
+  monthly_cloudwatch_budget_amount = 5
+}

--- a/security/account.hcl
+++ b/security/account.hcl
@@ -1,6 +1,6 @@
 # Set account-wide variables
 locals {
-  account_name = "security"
-  account_role = "security"
-
+  account_name                                   = "security"
+  account_role                                   = "security"
+  budget_monitoring_notification_email_addresses = ["eop+eopsecurity_budget_notifications@gw.govt.nz"]
 }

--- a/shared/_global/budget-monitoring/terragrunt.hcl
+++ b/shared/_global/budget-monitoring/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/landingzone/budget-monitoring.hcl"
+}
+
+inputs = {
+  total_monthly_budget_amount      = 75
+  monthly_cloudwatch_budget_amount = 5
+}

--- a/shared/account.hcl
+++ b/shared/account.hcl
@@ -1,6 +1,6 @@
 # Set account-wide variables
 locals {
-  account_name = "shared"
-  account_role = "shared"
-
+  account_name                                   = "shared"
+  account_role                                   = "shared"
+  budget_monitoring_notification_email_addresses = ["eop+eopshared_budget_notifications@gw.govt.nz"]
 }


### PR DESCRIPTION
Build should succeed after the first PR is merged / deployed

Creates:
- Budgets for Overall cost and for Cloudwatch

The email addresses for notifications had to be done in code as you are not allowed to create a Budget without a notification point


