### PR TITLE
Budgets 3 - Be more Generous 

### DIFF
--- a/_envcommon/landingzone/budget-monitoring.hcl
+++ b/_envcommon/landingzone/budget-monitoring.hcl
@@ -8,8 +8,8 @@ locals {
 }
 
 inputs = {
-  total_monthly_budget_amount      = 1250.00
-  monthly_cloudwatch_budget_amount = 150
+  total_monthly_budget_amount      = 2000
+  monthly_cloudwatch_budget_amount = 500
 
   notification_email_addresses = setunion(local.account_vars.locals.budget_monitoring_notification_email_addresses, local.common_vars.locals.budget_monitoring_notification_email_addresses)
 }

--- a/logs/_global/budget-monitoring/terragrunt.hcl
+++ b/logs/_global/budget-monitoring/terragrunt.hcl
@@ -7,6 +7,6 @@ include "envcommon" {
 }
 
 inputs = {
-  total_monthly_budget_amount      = 100
-  monthly_cloudwatch_budget_amount = 5
+  total_monthly_budget_amount      = 140
+  monthly_cloudwatch_budget_amount = 35
 }

--- a/modules/budget-monitoring/main.tf
+++ b/modules/budget-monitoring/main.tf
@@ -33,6 +33,10 @@ resource "aws_budgets_budget" "monthly_cloudwatch_budget" {
 
   time_period_start = "2022-10-01_00:00"
 
+  cost_filters = {
+    Service  = "AmazonCloudWatch"
+  }
+
   notification {
     comparison_operator        = "GREATER_THAN"
     threshold                  = 100

--- a/security/_global/budget-monitoring/terragrunt.hcl
+++ b/security/_global/budget-monitoring/terragrunt.hcl
@@ -7,6 +7,6 @@ include "envcommon" {
 }
 
 inputs = {
-  total_monthly_budget_amount      = 75
-  monthly_cloudwatch_budget_amount = 5
+  total_monthly_budget_amount      = 120
+  monthly_cloudwatch_budget_amount = 30
 }

--- a/shared/_global/budget-monitoring/terragrunt.hcl
+++ b/shared/_global/budget-monitoring/terragrunt.hcl
@@ -7,6 +7,6 @@ include "envcommon" {
 }
 
 inputs = {
-  total_monthly_budget_amount      = 75
-  monthly_cloudwatch_budget_amount = 5
+  total_monthly_budget_amount      = 120
+  monthly_cloudwatch_budget_amount = 30
 }


### PR DESCRIPTION
Two changes: 
* There was a mistake that the Cloudwatch budget wasn't actually filtering to Cloudwatch
* Just adjusted all the budgets to be more generous, as false alarms have already been triggered and given the low(ish) dollar amounts the difference between this and the more generous values isn't a huge deal.

New values are all approx 2x the September total bill, and Cloudwatch set as 1/4 of that. 
e.g. the security account cost $60, so double that for $120 and 1/4 of that for $30