### PR TITLE
Update to latest gwio modules

### DIFF
--- a/_envcommon/data-stores/aurora.hcl
+++ b/_envcommon/data-stores/aurora.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.96.9"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/data-stores/msk.hcl
+++ b/_envcommon/data-stores/msk.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.12.2"
+  source = "${local.source_base_url}?ref=v0.12.4"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/data-stores/redis.hcl
+++ b/_envcommon/data-stores/redis.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.96.9"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/landingzone/account-baseline-app-base.hcl
+++ b/_envcommon/landingzone/account-baseline-app-base.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.105.1"
+  source = "${local.source_base_url}?ref=v0.107.5"
 
   # This module deploys some resources (e.g., AWS Config) across all AWS regions, each of which needs its own provider,
   # which in Terraform means a separate process. To avoid all these processes thrashing the CPU, which leads to network
@@ -49,7 +49,6 @@ provider "aws" {
   # Skip credential validation and account ID retrieval for disabled or restricted regions
   skip_credentials_validation = ${contains(coalesce(local.opt_in_regions, []), region) ? "false" : "true"}
   skip_requesting_account_id  = ${contains(coalesce(local.opt_in_regions, []), region) ? "false" : "true"}
-  skip_get_ec2_platforms      = ${contains(coalesce(local.opt_in_regions, []), region) ? "false" : "true"}
 }
 %{endfor}
 EOF

--- a/_envcommon/mgmt/bastion-host.hcl
+++ b/_envcommon/mgmt/bastion-host.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.105.1"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/mgmt/ecs-deploy-runner.hcl
+++ b/_envcommon/mgmt/ecs-deploy-runner.hcl
@@ -12,7 +12,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.105.1"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -52,7 +52,6 @@ provider "aws" {
   # Skip credential validation and account ID retrieval for disabled or restricted regions
   skip_credentials_validation = ${contains(coalesce(local.opt_in_regions, []), region) ? "false" : "true"}
   skip_requesting_account_id  = ${contains(coalesce(local.opt_in_regions, []), region) ? "false" : "true"}
-  skip_get_ec2_platforms      = ${contains(coalesce(local.opt_in_regions, []), region) ? "false" : "true"}
 }
 %{endfor}
 EOF

--- a/_envcommon/mgmt/vpc-mgmt.hcl
+++ b/_envcommon/mgmt/vpc-mgmt.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.104.19"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/networking/alb-eop-ingest-api.hcl
+++ b/_envcommon/networking/alb-eop-ingest-api.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.96.9"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 dependency "vpc" {

--- a/_envcommon/networking/alb-eop-manager.hcl
+++ b/_envcommon/networking/alb-eop-manager.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.96.9"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 dependency "vpc" {

--- a/_envcommon/networking/route53-private.hcl
+++ b/_envcommon/networking/route53-private.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.96.9"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/networking/route53-public.hcl
+++ b/_envcommon/networking/route53-public.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.96.9"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/networking/sns-topics.hcl
+++ b/_envcommon/networking/sns-topics.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.96.9"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/networking/vpc-app.hcl
+++ b/_envcommon/networking/vpc-app.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.99.0"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/services/ecs-eop-hilltop-crawler.hcl
+++ b/_envcommon/services/ecs-eop-hilltop-crawler.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.100.0"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/services/ecs-eop-ingest-api.hcl
+++ b/_envcommon/services/ecs-eop-ingest-api.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.100.0"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/services/ecs-eop-manager-hilltop-consumer.hcl
+++ b/_envcommon/services/ecs-eop-manager-hilltop-consumer.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.100.0"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/services/ecs-eop-manager.hcl
+++ b/_envcommon/services/ecs-eop-manager.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.100.0"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/services/ecs-eop-tileserver.hcl
+++ b/_envcommon/services/ecs-eop-tileserver.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.100.0"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/services/ecs-fargate-cluster.hcl
+++ b/_envcommon/services/ecs-fargate-cluster.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.96.9"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 locals {

--- a/_envcommon/services/static-site-eop-plan-limits.hcl
+++ b/_envcommon/services/static-site-eop-plan-limits.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.96.4"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 
 dependency "acm_tls_certificate" {

--- a/eopdev/_global/route53-public/terragrunt.hcl
+++ b/eopdev/_global/route53-public/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopdev/ap-southeast-2/_regional/sns-topic/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/_regional/sns-topic/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopdev/ap-southeast-2/eopdev/data-stores/redis/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/eopdev/data-stores/redis/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopdev/ap-southeast-2/eopdev/networking/alb-eop-ingest-api/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/eopdev/networking/alb-eop-ingest-api/terragrunt.hcl
@@ -1,7 +1,3 @@
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 include "root" {
   path = find_in_parent_folders()
 }

--- a/eopdev/ap-southeast-2/eopdev/networking/alb-eop-manager/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/eopdev/networking/alb-eop-manager/terragrunt.hcl
@@ -1,7 +1,3 @@
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 include "root" {
   path = find_in_parent_folders()
 }

--- a/eopdev/ap-southeast-2/eopdev/networking/route53-private/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/eopdev/networking/route53-private/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-hilltop-crawler/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-hilltop-crawler/module_config.hcl
@@ -1,4 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  container_image_tag = "023722201d827470a709343f7f68993dc00c331a"
+  container_image_tag = "f4db299e5bccd51b4d70812e5fdf9581663d178b"
 }

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-ingest-api/module_config.hcl
@@ -1,4 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  container_image_tag = "023722201d827470a709343f7f68993dc00c331a"
+  container_image_tag = "24c6781a2f136a02ec53fc43b65bfda9ffe1b799"
 }

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-manager/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-manager/module_config.hcl
@@ -1,4 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  container_image_tag = "8ed42af534f3038c37885e10f96bc1685a71f848"
+  container_image_tag = "0f5274b904d2ac3335a81265848bc4c8d22f95bc"
 }

--- a/eopdev/ap-southeast-2/eopdev/services/ecs-fargate-cluster/terragrunt.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-fargate-cluster/terragrunt.hcl
@@ -1,7 +1,3 @@
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 include "root" {
   path = find_in_parent_folders()
 }

--- a/eopdev/us-east-1/acm-tls-certificates/terragrunt.hcl
+++ b/eopdev/us-east-1/acm-tls-certificates/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.28.3"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.29.18"
 }
 
 include "root" {

--- a/eopprod/_global/route53-public/terragrunt.hcl
+++ b/eopprod/_global/route53-public/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopprod/ap-southeast-2/_regional/sns-topic/terragrunt.hcl
+++ b/eopprod/ap-southeast-2/_regional/sns-topic/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopprod/ap-southeast-2/eopprod/data-stores/redis/terragrunt.hcl
+++ b/eopprod/ap-southeast-2/eopprod/data-stores/redis/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopprod/ap-southeast-2/eopprod/networking/alb-eop-ingest-api/terragrunt.hcl
+++ b/eopprod/ap-southeast-2/eopprod/networking/alb-eop-ingest-api/terragrunt.hcl
@@ -1,7 +1,3 @@
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 include "root" {
   path = find_in_parent_folders()
 }

--- a/eopprod/ap-southeast-2/eopprod/networking/alb-eop-manager/terragrunt.hcl
+++ b/eopprod/ap-southeast-2/eopprod/networking/alb-eop-manager/terragrunt.hcl
@@ -1,7 +1,3 @@
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 include "root" {
   path = find_in_parent_folders()
 }

--- a/eopprod/ap-southeast-2/eopprod/networking/route53-private/terragrunt.hcl
+++ b/eopprod/ap-southeast-2/eopprod/networking/route53-private/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopprod/ap-southeast-2/eopprod/services/ecs-fargate-cluster/terragrunt.hcl
+++ b/eopprod/ap-southeast-2/eopprod/services/ecs-fargate-cluster/terragrunt.hcl
@@ -1,7 +1,3 @@
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 include "root" {
   path = find_in_parent_folders()
 }

--- a/eopprod/us-east-1/acm-tls-certificates/terragrunt.hcl
+++ b/eopprod/us-east-1/acm-tls-certificates/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.28.3"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.29.18"
 }
 
 include "root" {

--- a/eopstage/_global/route53-public/terragrunt.hcl
+++ b/eopstage/_global/route53-public/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopstage/ap-southeast-2/_regional/sns-topic/terragrunt.hcl
+++ b/eopstage/ap-southeast-2/_regional/sns-topic/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopstage/ap-southeast-2/eopstage/data-stores/redis/terragrunt.hcl
+++ b/eopstage/ap-southeast-2/eopstage/data-stores/redis/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopstage/ap-southeast-2/eopstage/networking/alb-eop-ingest-api/terragrunt.hcl
+++ b/eopstage/ap-southeast-2/eopstage/networking/alb-eop-ingest-api/terragrunt.hcl
@@ -1,7 +1,3 @@
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 include "root" {
   path = find_in_parent_folders()
 }

--- a/eopstage/ap-southeast-2/eopstage/networking/alb-eop-manager/terragrunt.hcl
+++ b/eopstage/ap-southeast-2/eopstage/networking/alb-eop-manager/terragrunt.hcl
@@ -1,7 +1,3 @@
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 include "root" {
   path = find_in_parent_folders()
 }

--- a/eopstage/ap-southeast-2/eopstage/networking/route53-private/terragrunt.hcl
+++ b/eopstage/ap-southeast-2/eopstage/networking/route53-private/terragrunt.hcl
@@ -1,10 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
-# Override the terraform source with the actual version we want to deploy.
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 # Include the root `terragrunt.hcl` configuration, which has settings common across all environments & components.
 include "root" {
   path = find_in_parent_folders()

--- a/eopstage/ap-southeast-2/eopstage/services/ecs-fargate-cluster/terragrunt.hcl
+++ b/eopstage/ap-southeast-2/eopstage/services/ecs-fargate-cluster/terragrunt.hcl
@@ -1,7 +1,3 @@
-terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
-}
-
 include "root" {
   path = find_in_parent_folders()
 }

--- a/eopstage/us-east-1/acm-tls-certificates/terragrunt.hcl
+++ b/eopstage/us-east-1/acm-tls-certificates/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.28.3"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.29.18"
 }
 
 include "root" {

--- a/modules/budget-monitoring/main.tf
+++ b/modules/budget-monitoring/main.tf
@@ -33,8 +33,12 @@ resource "aws_budgets_budget" "monthly_cloudwatch_budget" {
 
   time_period_start = "2022-10-01_00:00"
 
-  cost_filters = {
-    Service  = "AmazonCloudWatch"
+  cost_filter {
+    name = "Service"
+    values = [
+      "AmazonCloudWatch"
+    ]
+
   }
 
   notification {

--- a/security/_global/account-baseline/terragrunt.hcl
+++ b/security/_global/account-baseline/terragrunt.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.99.0"
+  source = "${local.source_base_url}?ref=v0.107.5"
 
   # This module deploys some resources (e.g., AWS Config) across all AWS regions, each of which needs its own provider,
   # which in Terraform means a separate process. To avoid all these processes thrashing the CPU, which leads to network
@@ -53,7 +53,6 @@ provider "aws" {
   # Skip credential validation and account ID retrieval for disabled or restricted regions
   skip_credentials_validation = ${contains(coalesce(local.opt_in_regions, []), region) ? "false" : "true"}
   skip_requesting_account_id  = ${contains(coalesce(local.opt_in_regions, []), region) ? "false" : "true"}
-  skip_get_ec2_platforms      = ${contains(coalesce(local.opt_in_regions, []), region) ? "false" : "true"}
 }
 %{endfor}
 EOF

--- a/shared/ap-southeast-2/_regional/ecr-repos/terragrunt.hcl
+++ b/shared/ap-southeast-2/_regional/ecr-repos/terragrunt.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.96.9"
+  source = "${local.source_base_url}?ref=v0.107.5"
 }
 # Include all settings from the root terragrunt.hcl file
 include {

--- a/shared/ap-southeast-2/_regional/shared-secret-resource-policies/terragrunt.hcl
+++ b/shared/ap-southeast-2/_regional/shared-secret-resource-policies/terragrunt.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.65.8"
+  source = "${local.source_base_url}?ref=v0.69.3"
 }
 # Include all settings from the root terragrunt.hcl file
 include {

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -53,7 +53,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.9"
+      version = "~> 5.25"
     }
   }
 }


### PR DESCRIPTION
Update to the latest versions

Note there are 3 Gruntworks Repos that we refer to from our code
* Service Catalog. Which is like 95% of the references v0.107.5
* terraform-aws-load-balancer
* terraform-aws-security

There is also a bunch of code removed where modules versions were being overridden in the environment specific files 

e.g.
```
# Override the terraform source with the actual version we want to deploy.
terraform {
  source = "${include.envcommon.locals.source_base_url}?ref=v0.96.9"
}
```

This was just a hangover from the original Gruntworks code have examples of how you could do that to partially migrate things