### PR TITLE
Move to gw modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ helping with development.
 
 This code is built from the [Gruntwork Reference Architecture](https://gruntwork.io/reference-architecture/) using
 services from the [Gruntwork
-AWS Service Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog). There is supporting documentation
+AWS Service Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog). There is supporting documentation
 in the `./docs` folder of this repo, which was initially provided by Gruntworks during the reference architecture setup,
 which is useful but quite generic, it will be updated over time to be more specific to EOP.
 

--- a/_ci/app-templates/scripts/install.sh
+++ b/_ci/app-templates/scripts/install.sh
@@ -19,10 +19,10 @@ function run {
 
   curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/main/bootstrap-gruntwork-installer.sh \
     | bash /dev/stdin --version "$gruntwork_installer_version"
-  gruntwork-install --repo "https://github.com/gruntwork-io/terraform-aws-ci" \
+  gruntwork-install --repo "https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-ci" \
     --binary-name "infrastructure-deployer" \
     --tag "$module_ci_version"
-  gruntwork-install --repo "https://github.com/gruntwork-io/terraform-aws-security" \
+  gruntwork-install --repo "https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security" \
     --module-name "aws-auth" \
     --tag "$module_security_version"
 }

--- a/_ci/scripts/install.sh
+++ b/_ci/scripts/install.sh
@@ -19,13 +19,13 @@ function run {
 
   curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/main/bootstrap-gruntwork-installer.sh \
     | bash /dev/stdin --version "$gruntwork_installer_version"
-  gruntwork-install --repo "https://github.com/gruntwork-io/terraform-aws-ci" \
+  gruntwork-install --repo "https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-ci" \
     --binary-name "infrastructure-deployer" \
     --tag "$module_ci_version"
-  gruntwork-install --repo "https://github.com/gruntwork-io/terraform-aws-ci" \
+  gruntwork-install --repo "https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-ci" \
     --module-name "terraform-helpers" \
     --tag "$module_ci_version"
-  gruntwork-install --repo "https://github.com/gruntwork-io/terraform-aws-security" \
+  gruntwork-install --repo "https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security" \
     --module-name "aws-auth" \
     --tag "$module_security_version"
 }

--- a/_envcommon/data-stores/aurora.hcl
+++ b/_envcommon/data-stores/aurora.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/data-stores/aurora.hcl
+++ b/_envcommon/data-stores/aurora.hcl
@@ -56,7 +56,7 @@ dependency "sns" {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/data-stores/aurora"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/data-stores/aurora"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/data-stores/msk.hcl
+++ b/_envcommon/data-stores/msk.hcl
@@ -32,7 +32,7 @@ dependency "network_bastion" {
 
 
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-messaging.git//modules/msk"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-messaging.git//modules/msk"
   account_vars    = read_terragrunt_config(find_in_parent_folders("account.hcl"))
   account_name    = local.account_vars.locals.account_name
 }

--- a/_envcommon/data-stores/redis.hcl
+++ b/_envcommon/data-stores/redis.hcl
@@ -50,7 +50,7 @@ dependency "sns" {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/data-stores/redis"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/data-stores/redis"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/data-stores/redis.hcl
+++ b/_envcommon/data-stores/redis.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/landingzone/account-baseline-app-base.hcl
+++ b/_envcommon/landingzone/account-baseline-app-base.hcl
@@ -58,7 +58,7 @@ EOF
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/landingzone/account-baseline-app"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/landingzone/account-baseline-app"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/landingzone/account-baseline-app-base.hcl
+++ b/_envcommon/landingzone/account-baseline-app-base.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 
   # This module deploys some resources (e.g., AWS Config) across all AWS regions, each of which needs its own provider,
   # which in Terraform means a separate process. To avoid all these processes thrashing the CPU, which leads to network

--- a/_envcommon/mgmt/bastion-host.hcl
+++ b/_envcommon/mgmt/bastion-host.hcl
@@ -43,7 +43,7 @@ dependency "sns" {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/mgmt/bastion-host"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/mgmt/bastion-host"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/mgmt/bastion-host.hcl
+++ b/_envcommon/mgmt/bastion-host.hcl
@@ -92,7 +92,7 @@ inputs = {
   allow_ssh_from_cidr_list = local.common_vars.locals.ssh_ip_allow_list
 
   # Access the VPN server over SSH using ssh-grunt.
-  # See: https://github.com/gruntwork-io/terraform-aws-security/blob/master/modules/ssh-grunt
+  # See: https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security/blob/master/modules/ssh-grunt
   enable_ssh_grunt                    = true
   ssh_grunt_iam_group                 = local.common_vars.locals.ssh_grunt_users_group
   ssh_grunt_iam_group_sudo            = local.common_vars.locals.ssh_grunt_sudo_users_group

--- a/_envcommon/mgmt/bastion-host.hcl
+++ b/_envcommon/mgmt/bastion-host.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/mgmt/ecs-deploy-runner.hcl
+++ b/_envcommon/mgmt/ecs-deploy-runner.hcl
@@ -12,7 +12,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/mgmt/ecs-deploy-runner.hcl
+++ b/_envcommon/mgmt/ecs-deploy-runner.hcl
@@ -61,7 +61,7 @@ EOF
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/mgmt/ecs-deploy-runner"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/mgmt/ecs-deploy-runner"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/mgmt/vpc-mgmt.hcl
+++ b/_envcommon/mgmt/vpc-mgmt.hcl
@@ -17,7 +17,7 @@ terraform {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc-mgmt"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/networking/vpc-mgmt"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/mgmt/vpc-mgmt.hcl
+++ b/_envcommon/mgmt/vpc-mgmt.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/networking/alb-eop-ingest-api.hcl
+++ b/_envcommon/networking/alb-eop-ingest-api.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 dependency "vpc" {

--- a/_envcommon/networking/alb-eop-ingest-api.hcl
+++ b/_envcommon/networking/alb-eop-ingest-api.hcl
@@ -24,7 +24,7 @@ dependency "route53" {
 }
 
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/alb"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/networking/alb"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/networking/alb-eop-manager.hcl
+++ b/_envcommon/networking/alb-eop-manager.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 dependency "vpc" {

--- a/_envcommon/networking/alb-eop-manager.hcl
+++ b/_envcommon/networking/alb-eop-manager.hcl
@@ -24,7 +24,7 @@ dependency "route53" {
 }
 
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/alb"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/networking/alb"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/networking/route53-private.hcl
+++ b/_envcommon/networking/route53-private.hcl
@@ -30,7 +30,7 @@ dependency "vpc" {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/route53"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/networking/route53"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/networking/route53-private.hcl
+++ b/_envcommon/networking/route53-private.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/networking/route53-public.hcl
+++ b/_envcommon/networking/route53-public.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/networking/route53-public.hcl
+++ b/_envcommon/networking/route53-public.hcl
@@ -17,7 +17,7 @@ terraform {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/route53"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/networking/route53"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/networking/sns-topics.hcl
+++ b/_envcommon/networking/sns-topics.hcl
@@ -34,7 +34,7 @@ dependency "account_baseline" {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/sns-topics"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/networking/sns-topics"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/networking/sns-topics.hcl
+++ b/_envcommon/networking/sns-topics.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/networking/vpc-app.hcl
+++ b/_envcommon/networking/vpc-app.hcl
@@ -17,7 +17,7 @@ terraform {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/networking/vpc"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/networking/vpc-app.hcl
+++ b/_envcommon/networking/vpc-app.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/_envcommon/services/ecs-eop-hilltop-crawler.hcl
+++ b/_envcommon/services/ecs-eop-hilltop-crawler.hcl
@@ -63,7 +63,7 @@ dependency "sns" {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/services/ecs-service"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/services/ecs-service"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/services/ecs-eop-hilltop-crawler.hcl
+++ b/_envcommon/services/ecs-eop-hilltop-crawler.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/services/ecs-eop-ingest-api.hcl
+++ b/_envcommon/services/ecs-eop-ingest-api.hcl
@@ -65,7 +65,7 @@ dependency "alb" {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/services/ecs-service"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/services/ecs-service"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/services/ecs-eop-ingest-api.hcl
+++ b/_envcommon/services/ecs-eop-ingest-api.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/services/ecs-eop-manager-hilltop-consumer.hcl
+++ b/_envcommon/services/ecs-eop-manager-hilltop-consumer.hcl
@@ -75,7 +75,7 @@ dependency "alb" {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/services/ecs-service"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/services/ecs-service"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/services/ecs-eop-manager-hilltop-consumer.hcl
+++ b/_envcommon/services/ecs-eop-manager-hilltop-consumer.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/services/ecs-eop-manager.hcl
+++ b/_envcommon/services/ecs-eop-manager.hcl
@@ -75,7 +75,7 @@ dependency "alb" {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/services/ecs-service"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/services/ecs-service"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/services/ecs-eop-manager.hcl
+++ b/_envcommon/services/ecs-eop-manager.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/services/ecs-eop-tileserver.hcl
+++ b/_envcommon/services/ecs-eop-tileserver.hcl
@@ -72,7 +72,7 @@ dependency "shared_secret" {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/services/ecs-service"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/services/ecs-service"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/_envcommon/services/ecs-eop-tileserver.hcl
+++ b/_envcommon/services/ecs-eop-tileserver.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 dependency "eop_secrets" {

--- a/_envcommon/services/ecs-fargate-cluster.hcl
+++ b/_envcommon/services/ecs-fargate-cluster.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/services/ecs-fargate-cluster"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/services/ecs-fargate-cluster"
 
   account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
   account_name = local.account_vars.locals.account_name

--- a/_envcommon/services/ecs-fargate-cluster.hcl
+++ b/_envcommon/services/ecs-fargate-cluster.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 locals {

--- a/_envcommon/services/static-site-eop-plan-limits.hcl
+++ b/_envcommon/services/static-site-eop-plan-limits.hcl
@@ -32,7 +32,7 @@ EOF
 }
 
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/services/public-static-website"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/services/public-static-website"
   account_vars    = read_terragrunt_config(find_in_parent_folders("account.hcl"))
 }
 

--- a/_envcommon/services/static-site-eop-plan-limits.hcl
+++ b/_envcommon/services/static-site-eop-plan-limits.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 
 dependency "acm_tls_certificate" {

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -5,7 +5,7 @@ This documentation contains an overview of the architecture deployed and managed
 First, the short version:
 
 - This is an end-to-end tech stack for [Amazon Web Services (AWS)](https://aws.amazon.com/) that incluldes all the
-  basic infrastructure a company needs, including the network topology, orchestration tools (e.g., Kubernetes or ECS), databases, caches, load balancers, CI/CD pipeline, monitoring, alerting, log aggregation, etc.- It's built on top of the [Gruntwork Service Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog).
+  basic infrastructure a company needs, including the network topology, orchestration tools (e.g., Kubernetes or ECS), databases, caches, load balancers, CI/CD pipeline, monitoring, alerting, log aggregation, etc.- It's built on top of the [Gruntwork Service Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog).
 - It's all defined and managed as code using tools such as [Terraform](https://www.terraform.io/), [Packer](https://www.packer.io/), and [Docker](https://www.docker.com/).
 
 Here's a diagram that shows a rough overview of what the Reference Architecture looks like:
@@ -44,7 +44,7 @@ All of the infrastructure in this repo is managed as **code** using [Terragrunt]
 
 * You can package your infrastructure as reusable, documented, battle-tested modules that make it easier to scale and
   evolve your infrastructure. In fact, most of the infrastructure code in this architecture is deployed from the service modules in the
-  [Gruntwork Service Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/).
+  [Gruntwork Service Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/).
 
 For more info on Infrastructure as Code and Terraform, check out [A Comprehensive Guide to
 Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca) and our guide on [How to use the Gruntwork Infrastructure as Code Library](https://gruntwork.io/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library/).
@@ -114,7 +114,7 @@ Where:
   Instances, Auto Scaling Groups, ECS Clusters, Databases, Load Balancers, and so on. These resources are further
   organized by the overarching category that they relate to, such as `networking` and `services`. Note that the
   Terraform code for most of these resources lives in the [terraform-aws-service-catalog
-  repo](https://github.com/gruntwork-io/terraform-aws-service-catalog).
+  repo](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog).
 
 
 
@@ -161,7 +161,7 @@ can be useful for monitoring and auditing network traffic across the VPC. Each V
 Logs, under the log group `VPC_NAME-vpc-flow-logs`, where the `VPC_NAME` is an input variable to the `vpc` module.
 
 To learn more about VPCs and subnets, check out the Gruntwork [vpc
-service](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/main/modules/networking/vpc).
+service](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/main/modules/networking/vpc).
 
 
 
@@ -194,7 +194,7 @@ VPN client, you are "in the network", and will be able to access the private res
 to your EC2 Instances).
 
 For more info, see the [openvpn
-service](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/main/modules/mgmt/openvpn-server) and the VPN
+service](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/main/modules/mgmt/openvpn-server) and the VPN
 section of the [Authentication docs](02-authenticate.md).
 
 
@@ -223,7 +223,7 @@ We are using [Amazon Route 53](https://aws.amazon.com/route53/) to configure DNS
 have configured SSL/TLS certificates for your domain names using [Amazon's Certificate Manager
 (ACM)](https://aws.amazon.com/certificate-manager/), which issues certificates that are free and renew automatically.
 
-For more info, see the [route53 service](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/main/modules/networking/route53).
+For more info, see the [route53 service](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/main/modules/networking/route53).
 
 
 
@@ -239,13 +239,13 @@ We have configured security best practices in every aspect of this infrastructur
 * **Application secrets**: see secrets management section of the [Deploy your Apps docs](04-deploy-apps.md).
 * **User accounts**: see the [Authentication docs](02-authenticate.md).
 
-* **Auditing**: see the [CloudTrail](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail) and
-  [AWS Config](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config) modules.
+* **Auditing**: see the [CloudTrail](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security/tree/main/modules/cloudtrail) and
+  [AWS Config](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security/tree/main/modules/aws-config) modules.
 
-* **Intrusion detection**: see the [fail2ban](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/fail2ban)
-  and [GuardDuty](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty-multi-region) modules.
+* **Intrusion detection**: see the [fail2ban](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security/tree/main/modules/fail2ban)
+  and [GuardDuty](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security/tree/main/modules/guardduty-multi-region) modules.
 
-* **Security updates**: see the [auto-update module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/auto-update).
+* **Security updates**: see the [auto-update module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security/tree/main/modules/auto-update).
 
 Check out [Gruntwork Security Best
 Practices](https://docs.google.com/document/d/e/2PACX-1vTikva7hXPd2h1SSglJWhlW8W6qhMlZUxl0qQ9rUJ0OX22CQNeM-91w4lStRk9u2zQIn6lPejUbe-dl/pub)

--- a/docs/02-authenticate.md
+++ b/docs/02-authenticate.md
@@ -149,7 +149,7 @@ A few notes about the code above:
 1. **Groups**. We add each user to a set of IAM Groups: for example, we add Alice to IAM Groups that give her admin
    access in the dev, stage, and prod accounts, whereas Bob gets read-only access to prod, plus SSH access (with sudo
    permissions) to EC2 instances. For the full list of IAM Groups available out of the box, see the
-   [IAM Groups module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-groups#iam-groups).
+   [IAM Groups module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security/tree/main/modules/iam-groups#iam-groups).
 
 1. **PGP Keys**. We specify a PGP Key to use to encrypt any secrets for that user. Keys of the form `keybase:<username>`
    are automatically fetched for user `<username>` on [Keybase](https://keybase.io/).
@@ -203,7 +203,7 @@ To authenticate to any other account (e.g., dev, stage, prod), you need to:
 1. [Switching to an IAM Role in the other AWS account](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-console.html).
    To access other accounts, you "switch" to (AKA, "assume") an IAM Role defined in that account: e.g., to get
    read-only access to an account, you could assume the `allow-read-only-access-from-other-accounts` IAM Role. See the
-   [cross-account-iam-roles module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cross-account-iam-roles#iam-roles-intended-for-human-users)
+   [cross-account-iam-roles module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security/tree/main/modules/cross-account-iam-roles#iam-roles-intended-for-human-users)
    for the default set of IAM Roles that exist in each account. Note that to be able to access an IAM Role `xxx` in
    some account `yyy`, your IAM User must be in an IAM Group that has permissions to assume that IAM Role. For example,
    to assume the `allow-read-only-access-from-other-accounts` IAM Role in the prod account, you must be in the
@@ -226,7 +226,7 @@ A few important notes on authenticating via the CLI:
    your access keys and an MFA token. To authenticate to all other accounts (e.g., dev, stage, prod), you will need
    access keys, an MFA token, and the ARN of an IAM Role in that account to assume: e.g., to get read-only access to an
    account, you could assume the `allow-read-only-access-from-other-accounts` IAM Role. See the
-   [cross-account-iam-roles module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cross-account-iam-roles#iam-roles-intended-for-human-users)
+   [cross-account-iam-roles module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security/tree/main/modules/cross-account-iam-roles#iam-roles-intended-for-human-users)
    for the default set of IAM Roles that exist in each account. Note that to be able to access an IAM Role `xxx` in
    some account `yyy`, your IAM User must be in an IAM Group that has permissions to assume that IAM Role. For example,
    to assume the `allow-read-only-access-from-other-accounts` IAM Role in the prod account, you must be in the
@@ -322,7 +322,7 @@ You can SSH to any of your EC2 Instances as follows:
 
 ### (Recommended) ssh-grunt
 
-Every EC2 instance has [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt)
+Every EC2 instance has [ssh-grunt](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security/tree/main/modules/ssh-grunt)
 installed, which allows you to manage SSH access using IAM Groups. Here's how it works:
 
 1. [Add users to SSH IAM Groups](#add-users-to-ssh-iam-groups)
@@ -351,7 +351,7 @@ IAM Users](#configure-other-iam-users) for instructions).
 Your username for SSH is typically the same as your IAM User name. However, if your IAM User name has special
 characters that are not allowed by operating systems (e.g., most puncuation is not allowed), your SSH username may be a
 bit different, as specified in the [ssh-grunt
-documentation](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt#syncing-users-from-iam).
+documentation](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-security/tree/main/modules/ssh-grunt#syncing-users-from-iam).
 For example:
 
 * If your IAM User name is `josh`, your SSH username will also be `josh`.

--- a/docs/03-configure-gw-pipelines.md
+++ b/docs/03-configure-gw-pipelines.md
@@ -261,7 +261,7 @@ Once the branch is merged, updates to the `main` branch will trigger a build job
 
 ## Update the CI/CD pipeline itself
 
-The CI/CD pipeline uses the Gruntwork [terraform-aws-ci](https://github.com/gruntwork-io/terraform-aws-ci) repo code, so
+The CI/CD pipeline uses the Gruntwork [terraform-aws-ci](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-ci) repo code, so
 whenever there's a new release, it's a good idea to update your pipeline.
 
 Here are the manual steps for this process:

--- a/docs/04-deploy-apps.md
+++ b/docs/04-deploy-apps.md
@@ -267,7 +267,7 @@ For the purpose of this example, we will assume we want to deploy the simple web
 ### Deploying your configuration
 
 The above are the minimum set of configurations that you need to deploy the app. You can take a look at [`variables.tf`
-of `ecs-service`](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/main/modules/services/ecs-service)
+of `ecs-service`](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/main/modules/services/ecs-service)
 for all the options.
 
 Once you've verified that everything looks fine, change to the new ALB directory you created, and run:

--- a/docs/05-monitoring-alerting-logging.md
+++ b/docs/05-monitoring-alerting-logging.md
@@ -16,7 +16,7 @@ Page](https://console.aws.amazon.com/cloudwatch/home?#metricsV2:).
 * Most AWS services emit metrics by default, which you'll find under the "AWS Namespaces" (e.g. EC2, ECS, RDS).
 
 * Custom metrics show up under "Custom Namespaces." In particular, the [cloudwatch-memory-disk-metrics-scripts
-  module](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/metrics/) is installed on every
+  module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-monitoring/tree/main/modules/metrics/) is installed on every
   server to emit metrics not available from AWS by default, including memory and disk usage. You'll find these under
   the "Linux System" Namespace.
 
@@ -27,7 +27,7 @@ with the most useful metrics for your services and have that open on a big scree
 ## Alerts
 
 A number of alerts have been configured using the [alarms modules in
-terraform-aws-monitoring](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms) to notify you
+terraform-aws-monitoring](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-monitoring/tree/main/modules/alarms) to notify you
 in case of problems, such as a service running out of disk space or a load balancer seeing too many 5xx errors.
 
 * You can find all the alerts in the [CloudWatch Alarms
@@ -42,13 +42,13 @@ Page](https://console.aws.amazon.com/sns/v2/home?#/topics), select the `cloudwat
 Subscribe to topic."
 
 If you'd like alarm notifications to go to a Slack channel, check out the [sns-to-slack
-module](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/sns-to-slack).
+module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-monitoring/tree/main/modules/alarms/sns-to-slack).
 
 
 ## Logs
 
 All of your services have been configured using the [cloudwatch-log-aggregation-scripts
-module](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/logs/cloudwatch-log-aggregation-scripts)
+module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-monitoring/tree/main/modules/logs/cloudwatch-log-aggregation-scripts)
 to send their logs to [CloudWatch Logs](https://console.aws.amazon.com/cloudwatch/home?#logs:). Instead of SSHing to
 each server to see a log file, and worrying about losing those log files if the server fails, you can just go to the
 [CloudWatch Logs Page](https://console.aws.amazon.com/cloudwatch/home?#logs:) and browse and search log events for all

--- a/docs/06-adding-a-new-account.md
+++ b/docs/06-adding-a-new-account.md
@@ -165,7 +165,7 @@ If you are sharing encrypted AMIs, then you will also need to ensure the new acc
 encrypts the AMI root device. This is managed in the `shared` account baseline module.
 
 Finally, for the [ECS Deploy
-Runner](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner) to work, the new account
+Runner](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-ci/tree/main/modules/ecs-deploy-runner) to work, the new account
 needs to be able to access the secrets for accessing the remote repositories and the Docker images that back the build
 runners. Both of these are stored in the `shared` account.
 

--- a/docs/09-upgrading.md
+++ b/docs/09-upgrading.md
@@ -18,4 +18,4 @@ using the specified Terraform version.
 bucket containing all your Reference Architecture's state files.
 
 You can read more about how this works in the main
-[ECS Deploy Runner docs](https://github.com/gruntwork-io/terraform-aws-ci/blob/ee2d941946824bdabbac6830dc6cf66f9ee69bec/modules/ecs-deploy-runner/core-concepts.md#how-do-i-use-the-deploy-runner-with-multiple-terraform-versions).
+[ECS Deploy Runner docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-ci/blob/ee2d941946824bdabbac6830dc6cf66f9ee69bec/modules/ecs-deploy-runner/core-concepts.md#how-do-i-use-the-deploy-runner-with-multiple-terraform-versions).

--- a/eopdev/_global/account-baseline/README.md
+++ b/eopdev/_global/account-baseline/README.md
@@ -15,8 +15,8 @@ The account baseline includes the following configurations:
 
 
 
-For full details on what this configuration includes and how to use it, refer to the [`account-baseline-app` service catalog module](https://github.com/gruntwork-io/terraform-aws-service-catalog/blob/main/modules/landingzone/account-baseline-app/README.adoc). If you don't have access to this repo, email
+For full details on what this configuration includes and how to use it, refer to the [`account-baseline-app` service catalog module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/blob/main/modules/landingzone/account-baseline-app/README.adoc). If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/landingzone/account-baseline-app) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/landingzone/account-baseline-app) for more
 information about the underlying Terraform module.

--- a/eopdev/_global/route53-public/README.md
+++ b/eopdev/_global/route53-public/README.md
@@ -4,8 +4,8 @@ This directory manages an external, public facing [Route53
 Hosted Zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html).
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
 information about the underlying Terraform module.

--- a/eopdev/ap-southeast-2/eopdev/data-stores/aurora/README.md
+++ b/eopdev/ap-southeast-2/eopdev/data-stores/aurora/README.md
@@ -8,8 +8,8 @@ Cluster. The resources that are created include:
 1. A **Security Group** to limit access to the cluster.
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/aurora) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/aurora) for more
 information about the underlying Terraform module.

--- a/eopdev/ap-southeast-2/eopdev/data-stores/redis/README.md
+++ b/eopdev/ap-southeast-2/eopdev/data-stores/redis/README.md
@@ -9,8 +9,8 @@ Redis Replication Group. The resources that are created include:
 1. A **Security Group** to limit access to the Replication Group.
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/redis) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/redis) for more
 information about the underlying Terraform module.

--- a/eopdev/ap-southeast-2/eopdev/networking/route53-private/README.md
+++ b/eopdev/ap-southeast-2/eopdev/networking/route53-private/README.md
@@ -4,8 +4,8 @@ This directory manages an private, vpc facing [Route53
 Hosted Zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html).
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
 information about the underlying Terraform module.

--- a/eopdev/us-east-1/acm-tls-certificates/terragrunt.hcl
+++ b/eopdev/us-east-1/acm-tls-certificates/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.29.18"
+  source = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.29.18"
 }
 
 include "root" {

--- a/eopprod/_global/account-baseline/README.md
+++ b/eopprod/_global/account-baseline/README.md
@@ -15,8 +15,8 @@ The account baseline includes the following configurations:
 
 
 
-For full details on what this configuration includes and how to use it, refer to the [`account-baseline-app` service catalog module](https://github.com/gruntwork-io/terraform-aws-service-catalog/blob/main/modules/landingzone/account-baseline-app/README.adoc). If you don't have access to this repo, email
+For full details on what this configuration includes and how to use it, refer to the [`account-baseline-app` service catalog module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/blob/main/modules/landingzone/account-baseline-app/README.adoc). If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/landingzone/account-baseline-app) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/landingzone/account-baseline-app) for more
 information about the underlying Terraform module.

--- a/eopprod/_global/route53-public/README.md
+++ b/eopprod/_global/route53-public/README.md
@@ -4,8 +4,8 @@ This directory manages an external, public facing [Route53
 Hosted Zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html).
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
 information about the underlying Terraform module.

--- a/eopprod/ap-southeast-2/eopprod/data-stores/aurora/README.md
+++ b/eopprod/ap-southeast-2/eopprod/data-stores/aurora/README.md
@@ -8,8 +8,8 @@ Cluster. The resources that are created include:
 1. A **Security Group** to limit access to the cluster.
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/aurora) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/aurora) for more
 information about the underlying Terraform module.

--- a/eopprod/ap-southeast-2/eopprod/data-stores/redis/README.md
+++ b/eopprod/ap-southeast-2/eopprod/data-stores/redis/README.md
@@ -9,8 +9,8 @@ Redis Replication Group. The resources that are created include:
 1. A **Security Group** to limit access to the Replication Group.
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/redis) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/redis) for more
 information about the underlying Terraform module.

--- a/eopprod/ap-southeast-2/eopprod/networking/route53-private/README.md
+++ b/eopprod/ap-southeast-2/eopprod/networking/route53-private/README.md
@@ -4,8 +4,8 @@ This directory manages an private, vpc facing [Route53
 Hosted Zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html).
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
 information about the underlying Terraform module.

--- a/eopprod/us-east-1/acm-tls-certificates/terragrunt.hcl
+++ b/eopprod/us-east-1/acm-tls-certificates/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.29.18"
+  source = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.29.18"
 }
 
 include "root" {

--- a/eopstage/_global/account-baseline/README.md
+++ b/eopstage/_global/account-baseline/README.md
@@ -15,8 +15,8 @@ The account baseline includes the following configurations:
 
 
 
-For full details on what this configuration includes and how to use it, refer to the [`account-baseline-app` service catalog module](https://github.com/gruntwork-io/terraform-aws-service-catalog/blob/main/modules/landingzone/account-baseline-app/README.adoc). If you don't have access to this repo, email
+For full details on what this configuration includes and how to use it, refer to the [`account-baseline-app` service catalog module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/blob/main/modules/landingzone/account-baseline-app/README.adoc). If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/landingzone/account-baseline-app) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/landingzone/account-baseline-app) for more
 information about the underlying Terraform module.

--- a/eopstage/_global/route53-public/README.md
+++ b/eopstage/_global/route53-public/README.md
@@ -4,8 +4,8 @@ This directory manages an external, public facing [Route53
 Hosted Zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html).
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
 information about the underlying Terraform module.

--- a/eopstage/ap-southeast-2/eopstage/data-stores/aurora/README.md
+++ b/eopstage/ap-southeast-2/eopstage/data-stores/aurora/README.md
@@ -8,8 +8,8 @@ Cluster. The resources that are created include:
 1. A **Security Group** to limit access to the cluster.
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/aurora) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/aurora) for more
 information about the underlying Terraform module.

--- a/eopstage/ap-southeast-2/eopstage/data-stores/redis/README.md
+++ b/eopstage/ap-southeast-2/eopstage/data-stores/redis/README.md
@@ -9,8 +9,8 @@ Redis Replication Group. The resources that are created include:
 1. A **Security Group** to limit access to the Replication Group.
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/redis) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/data-stores/redis) for more
 information about the underlying Terraform module.

--- a/eopstage/ap-southeast-2/eopstage/networking/route53-private/README.md
+++ b/eopstage/ap-southeast-2/eopstage/networking/route53-private/README.md
@@ -4,8 +4,8 @@ This directory manages an private, vpc facing [Route53
 Hosted Zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html).
 
 Under the hood, this is all implemented using Terraform modules from the [Gruntwork Service
-Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog) repo. If you don't have access to this repo, email
+Catalog](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog) repo. If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/networking/route53) for more
 information about the underlying Terraform module.

--- a/eopstage/us-east-1/acm-tls-certificates/terragrunt.hcl
+++ b/eopstage/us-east-1/acm-tls-certificates/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.29.18"
+  source = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-load-balancer.git//modules/acm-tls-certificate?ref=v0.29.18"
 }
 
 include "root" {

--- a/logs/_global/account-baseline/README.md
+++ b/logs/_global/account-baseline/README.md
@@ -17,8 +17,8 @@ Since this is the logs account, it is the central account that other accounts us
 
 
 
-For full details on what this configuration includes and how to use it, refer to the [`account-baseline-app` service catalog module](https://github.com/gruntwork-io/terraform-aws-service-catalog/blob/main/modules/landingzone/account-baseline-app/README.adoc). If you don't have access to this repo, email
+For full details on what this configuration includes and how to use it, refer to the [`account-baseline-app` service catalog module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/blob/main/modules/landingzone/account-baseline-app/README.adoc). If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/landingzone/account-baseline-app) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/landingzone/account-baseline-app) for more
 information about the underlying Terraform module.

--- a/modules/cdn/main.tf
+++ b/modules/cdn/main.tf
@@ -57,7 +57,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 }
 
-# Based on https://github.com/gruntwork-io/terraform-aws-static-assets/blob/main/modules/s3-cloudfront/main.tf#L542
+# Based on https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-static-assets/blob/main/modules/s3-cloudfront/main.tf#L542
 module "access_logs" {
   source = "git::git@github.com:gruntwork-io/terraform-aws-security.git//modules/private-s3-bucket?ref=v0.65.3"
 

--- a/modules/cdn/main.tf
+++ b/modules/cdn/main.tf
@@ -59,10 +59,12 @@ resource "aws_cloudfront_distribution" "cdn" {
 
 # Based on https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-static-assets/blob/main/modules/s3-cloudfront/main.tf#L542
 module "access_logs" {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-security.git//modules/private-s3-bucket?ref=v0.65.3"
+  source = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-security.git//modules/private-s3-bucket?ref=v0.69.3-gwrc"
 
-  name          = "${var.domain_name}-cloudfront-logs"
-  sse_algorithm = "AES256"
+  name             = "${var.domain_name}-cloudfront-logs"
+  acl              = null
+  bucket_ownership = "ObjectWriter"
+  sse_algorithm    = "AES256"
 
   bucket_policy_statements = {
     AllowCloudfrontWriteS3AccessLog = {

--- a/security/_global/account-baseline/terragrunt.hcl
+++ b/security/_global/account-baseline/terragrunt.hcl
@@ -62,7 +62,7 @@ EOF
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/landingzone/account-baseline-security"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/landingzone/account-baseline-security"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/security/_global/account-baseline/terragrunt.hcl
+++ b/security/_global/account-baseline/terragrunt.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 
   # This module deploys some resources (e.g., AWS Config) across all AWS regions, each of which needs its own provider,
   # which in Terraform means a separate process. To avoid all these processes thrashing the CPU, which leads to network

--- a/shared/_global/account-baseline/README.md
+++ b/shared/_global/account-baseline/README.md
@@ -20,8 +20,8 @@ Since this is the shared-services account, it is responsible for sharing resourc
 
 For each account, the root account ARN (for example, `arn:aws:iam::111111111111:root`) is granted access to each key, allowing administrators in that account to delegate additional access as needed [using grants](https://docs.aws.amazon.com/kms/latest/developerguide/grants.html).
 
-For full details on what this configuration includes and how to use it, refer to the [`account-baseline-app` service catalog module](https://github.com/gruntwork-io/terraform-aws-service-catalog/blob/main/modules/landingzone/account-baseline-app/README.adoc). If you don't have access to this repo, email
+For full details on what this configuration includes and how to use it, refer to the [`account-baseline-app` service catalog module](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/blob/main/modules/landingzone/account-baseline-app/README.adoc). If you don't have access to this repo, email
 [support@gruntwork.io](mailto:support@gruntwork.io).
 
-See [the module docs](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.95.0/modules/landingzone/account-baseline-app) for more
+See [the module docs](https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/tree/v0.95.0/modules/landingzone/account-baseline-app) for more
 information about the underlying Terraform module.

--- a/shared/ap-southeast-2/_regional/amis/build_bastion_host.sh
+++ b/shared/ap-southeast-2/_regional/amis/build_bastion_host.sh
@@ -7,13 +7,13 @@
 # the Shared Services AWS account.
 #
 # This is the build script for the Bastion Host AMI. You can view the packer template at the following URL:
-# https://github.com/gruntwork-io/terraform-aws-service-catalog/blob/v0.95.0/modules/mgmt/bastion-host/bastion-host-ubuntu.pkr.hcl
+# https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/blob/v0.95.0/modules/mgmt/bastion-host/bastion-host-ubuntu.pkr.hcl
 #
 # Pass in the --run-local flag to build the image on the local machine, without going through the ECS Deploy Runner.
 
 set -e
 
-readonly PACKER_TEMPLATE_REPO="https://github.com/gruntwork-io/terraform-aws-service-catalog.git//modules/mgmt/bastion-host/bastion-host-ubuntu.pkr.hcl"
+readonly PACKER_TEMPLATE_REPO="https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/mgmt/bastion-host/bastion-host-ubuntu.pkr.hcl"
 readonly PACKER_TEMPLATE_REPO_REF="v0.99.0"
 readonly SERVICE_CATALOG_REF="v0.99.0"
 readonly DEPLOY_RUNNER_REGION="ap-southeast-2"

--- a/shared/ap-southeast-2/_regional/amis/build_ecs_cluster_instance.sh
+++ b/shared/ap-southeast-2/_regional/amis/build_ecs_cluster_instance.sh
@@ -7,13 +7,13 @@
 # the Shared Services AWS account.
 #
 # This is the build script for the ECS Cluster Instance AMI. You can view the packer template at the following URL:
-# https://github.com/gruntwork-io/terraform-aws-service-catalog/blob/v0.95.0/modules/services/ecs-cluster/ecs-node-al2.pkr.hcl
+# https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/blob/v0.95.0/modules/services/ecs-cluster/ecs-node-al2.pkr.hcl
 #
 # Pass in the --run-local flag to build the image on the local machine, without going through the ECS Deploy Runner.
 
 set -e
 
-readonly PACKER_TEMPLATE_REPO="https://github.com/gruntwork-io/terraform-aws-service-catalog.git//modules/services/ecs-cluster/ecs-node-al2.pkr.hcl"
+readonly PACKER_TEMPLATE_REPO="https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/services/ecs-cluster/ecs-node-al2.pkr.hcl"
 readonly PACKER_TEMPLATE_REPO_REF="v0.99.0"
 readonly SERVICE_CATALOG_REF="v0.99.0"
 readonly DEPLOY_RUNNER_REGION="ap-southeast-2"

--- a/shared/ap-southeast-2/_regional/amis/build_ecs_deploy_runner_worker.sh
+++ b/shared/ap-southeast-2/_regional/amis/build_ecs_deploy_runner_worker.sh
@@ -7,13 +7,13 @@
 # the Shared Services AWS account.
 #
 # This is the build script for the ECS Deploy Runner EC2 Workers AMI. You can view the packer template at the following URL:
-# https://github.com/gruntwork-io/terraform-aws-service-catalog/blob/v0.95.0/modules/mgmt/ecs-deploy-runner/ecs-deploy-runner-worker-al2.pkr.hcl
+# https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog/blob/v0.95.0/modules/mgmt/ecs-deploy-runner/ecs-deploy-runner-worker-al2.pkr.hcl
 #
 # Pass in the --run-local flag to build the image on the local machine, without going through the ECS Deploy Runner.
 
 set -e
 
-readonly PACKER_TEMPLATE_REPO="https://github.com/gruntwork-io/terraform-aws-service-catalog.git//modules/mgmt/ecs-deploy-runner/ecs-deploy-runner-worker-al2.pkr.hcl"
+readonly PACKER_TEMPLATE_REPO="https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/mgmt/ecs-deploy-runner/ecs-deploy-runner-worker-al2.pkr.hcl"
 readonly PACKER_TEMPLATE_REPO_REF="v0.99.0"
 readonly SERVICE_CATALOG_REF="v0.99.0"
 readonly DEPLOY_RUNNER_REGION="ap-southeast-2"

--- a/shared/ap-southeast-2/_regional/container_images/build_deploy_runner_image.sh
+++ b/shared/ap-southeast-2/_regional/container_images/build_deploy_runner_image.sh
@@ -7,11 +7,11 @@
 # the Shared Services AWS account.
 #
 # This is the build script for the Deploy Runner Docker image. You can view the Dockerfile at the following URL:
-# https://github.com/gruntwork-io/terraform-aws-ci/blob/v0.50.6/modules/ecs-deploy-runner/docker/deploy-runner
+# https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-ci/blob/v0.50.6/modules/ecs-deploy-runner/docker/deploy-runner
 
 set -e
 
-readonly DOCKERFILE_REPO="https://github.com/gruntwork-io/terraform-aws-ci.git"
+readonly DOCKERFILE_REPO="https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-ci.git"
 readonly DOCKERFILE_REPO_REF="v0.52.19"
 readonly DOCKERFILE_CONTEXT_PATH="modules/ecs-deploy-runner/docker/deploy-runner"
 readonly DEPLOY_RUNNER_REGION="ap-southeast-2"

--- a/shared/ap-southeast-2/_regional/container_images/build_kaniko_image.sh
+++ b/shared/ap-southeast-2/_regional/container_images/build_kaniko_image.sh
@@ -7,11 +7,11 @@
 # the Shared Services AWS account.
 #
 # This is the build script for the Kaniko Docker Image Builder Docker image. You can view the Dockerfile at the following URL:
-# https://github.com/gruntwork-io/terraform-aws-ci/blob/v0.50.6/modules/ecs-deploy-runner/docker/kaniko
+# https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-ci/blob/v0.50.6/modules/ecs-deploy-runner/docker/kaniko
 
 set -e
 
-readonly DOCKERFILE_REPO="https://github.com/gruntwork-io/terraform-aws-ci.git"
+readonly DOCKERFILE_REPO="https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-ci.git"
 readonly DOCKERFILE_REPO_REF="v0.52.19"
 readonly DOCKERFILE_CONTEXT_PATH="modules/ecs-deploy-runner/docker/kaniko"
 readonly DEPLOY_RUNNER_REGION="ap-southeast-2"

--- a/shared/ap-southeast-2/_regional/ecr-repos/terragrunt.hcl
+++ b/shared/ap-southeast-2/_regional/ecr-repos/terragrunt.hcl
@@ -21,7 +21,7 @@ include {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/data-stores/ecr-repos"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git//modules/data-stores/ecr-repos"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/shared/ap-southeast-2/_regional/ecr-repos/terragrunt.hcl
+++ b/shared/ap-southeast-2/_regional/ecr-repos/terragrunt.hcl
@@ -10,7 +10,7 @@
 # locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
 # local check out of the module for faster iteration.
 terraform {
-  source = "${local.source_base_url}?ref=v0.107.5"
+  source = "${local.source_base_url}?ref=v0.107.5-gwrc"
 }
 # Include all settings from the root terragrunt.hcl file
 include {

--- a/shared/ap-southeast-2/_regional/shared-secret-resource-policies/terragrunt.hcl
+++ b/shared/ap-southeast-2/_regional/shared-secret-resource-policies/terragrunt.hcl
@@ -21,7 +21,7 @@ include {
 # Locals are named constants that are reusable within the configuration.
 # ---------------------------------------------------------------------------------------------------------------------
 locals {
-  source_base_url = "git::git@github.com:gruntwork-io/terraform-aws-security.git//modules/secrets-manager-resource-policies"
+  source_base_url = "git::git@github.com:Greater-Wellington-Regional-Council/gwio_terraform-aws-security.git//modules/secrets-manager-resource-policies"
 
   # Automatically load common variables shared across all accounts
   common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))

--- a/shared/ap-southeast-2/mgmt/ecs-deploy-runner/terragrunt.hcl
+++ b/shared/ap-southeast-2/mgmt/ecs-deploy-runner/terragrunt.hcl
@@ -55,7 +55,7 @@ inputs = {
 
     allowed_repos = [
       local.common_vars.locals.infra_live_repo_https,
-      "https://github.com/gruntwork-io/terraform-aws-ci.git",
+      "https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-ci.git",
     ]
     allowed_repos_regex = []
     git_config = {
@@ -77,9 +77,9 @@ inputs = {
     allowed_repos = [
       local.common_vars.locals.infra_live_repo_ssh,
       # Also allow building from Gruntwork Service Catalog repo
-      "https://github.com/gruntwork-io/terraform-aws-service-catalog.git",
+      "https://github.com/Greater-Wellington-Regional-Council/gwio_terraform-aws-service-catalog.git",
       # Also allow building from Gruntwork Sample App repo
-      "https://github.com/gruntwork-io/aws-sample-app.git",
+      "https://github.com/Greater-Wellington-Regional-Council/aws-sample-app.git",
     ]
     allowed_repos_regex                     = []
     repo_access_ssh_key_secrets_manager_arn = null


### PR DESCRIPTION
Moves to point at the GWRC forks of the Gruntworks code.

* There are the sub modules that have been updated/versioned with the GWRC versions where there were links between modules. 
* The build amis task is currently failing, and I think the changes released in this version will resolve that for the next build. Caused by restrictions in what repos are allowed to trigger builds, which has now been updated to the GW ones.


