### PR TITLE
bugfix for ruamahanga allocation figure not showing

### DIFF
--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-manager/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-manager/module_config.hcl
@@ -1,4 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  container_image_tag = "0979f16382650fca3081c7789eb39ae39d11074a"
+  container_image_tag = "1b8b40d7cb7e9f20c7977c7ff00dc01e2931b064"
 }

--- a/eopprod/ap-southeast-2/eopprod/services/ecs-eop-manager/module_config.hcl
+++ b/eopprod/ap-southeast-2/eopprod/services/ecs-eop-manager/module_config.hcl
@@ -1,4 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  container_image_tag = "0979f16382650fca3081c7789eb39ae39d11074a"
+  container_image_tag = "1b8b40d7cb7e9f20c7977c7ff00dc01e2931b064"
 }

--- a/eopstage/ap-southeast-2/eopstage/services/ecs-eop-manager/module_config.hcl
+++ b/eopstage/ap-southeast-2/eopstage/services/ecs-eop-manager/module_config.hcl
@@ -1,4 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  container_image_tag = "0979f16382650fca3081c7789eb39ae39d11074a"
+  container_image_tag = "1b8b40d7cb7e9f20c7977c7ff00dc01e2931b064"
 }


### PR DESCRIPTION
adds a new row of data for the Ruamahanga region so that the catchment management unit displays its consented allocation.