### PR TITLE
consented_allocation fix

### DIFF
--- a/eopdev/ap-southeast-2/eopdev/services/ecs-eop-data-transformation/module_config.hcl
+++ b/eopdev/ap-southeast-2/eopdev/services/ecs-eop-data-transformation/module_config.hcl
@@ -1,4 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  container_image_tag = "37b5f6006c21e737b66cd1aca8b317beb5ac6982"
+  container_image_tag = "3bc765b195aef907f71a95d0daa44162af358002"
 }

--- a/eopprod/ap-southeast-2/eopprod/services/ecs-eop-data-transformation/module_config.hcl
+++ b/eopprod/ap-southeast-2/eopprod/services/ecs-eop-data-transformation/module_config.hcl
@@ -1,4 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  container_image_tag = "37b5f6006c21e737b66cd1aca8b317beb5ac6982"
+  container_image_tag = "3bc765b195aef907f71a95d0daa44162af358002"
 }

--- a/eopstage/ap-southeast-2/eopstage/services/ecs-eop-data-transformation/module_config.hcl
+++ b/eopstage/ap-southeast-2/eopstage/services/ecs-eop-data-transformation/module_config.hcl
@@ -1,4 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  container_image_tag = "37b5f6006c21e737b66cd1aca8b317beb5ac6982"
+  container_image_tag = "3bc765b195aef907f71a95d0daa44162af358002"
 }


### PR DESCRIPTION
deploy a newer version of the data transformation package that fixes a bug where some consents were getting double counted in consented allocation totals.