### PR TITLE
set kafka log retention to 1 week

### DIFF
--- a/_envcommon/data-stores/msk.hcl
+++ b/_envcommon/data-stores/msk.hcl
@@ -50,6 +50,7 @@ inputs = {
   server_properties = {
     "auto.create.topics.enable"  = "true"
     "default.replication.factor" = "2"
+    "log.retention.hours"        = "168"
   }
   client_sasl_scram_secret_arns = [
     dependency.eop_secrets.outputs.kafka_client_credentials_arn


### PR DESCRIPTION
Kafka currently retains messages indefinately and this has resulted in a storage full error in our staging envrionment.

This change will mean that messages are retained for 1 week, meaning old logs should be deleted and storage wont be an issue going forward.