### PR TITLE
increase working mem to 64MB

### DIFF
--- a/_envcommon/data-stores/aurora.hcl
+++ b/_envcommon/data-stores/aurora.hcl
@@ -125,6 +125,11 @@ inputs = {
         name         = "shared_preload_libraries"
         value        = "pg_stat_statements"
         apply_method = "immediate"
+      },
+      {
+        name         = "work_mem"
+        value        = "64MB"
+        apply_method = "immediate"
       }
     ]
   }


### PR DESCRIPTION
The working memory on our databases is set to the default of 4MB which is far to low given the the dbt workloads that we run against it every hour. 

this low number caused an excessive creation of temp files as part of database processing and we ran out of temp space, causing the dbt process to fail.

this config change increases that to 64MB. There are other higher options but setting this value too  high could cause the database to hit ram limits, so im trying 64mb as a sensible level, given we have 8gigs of total ram.