### PR TITLE
reduced size data model in data transformation

### DIFF
--- a/eopprod/ap-southeast-2/eopprod/services/ecs-eop-data-transformation/module_config.hcl
+++ b/eopprod/ap-southeast-2/eopprod/services/ecs-eop-data-transformation/module_config.hcl
@@ -1,4 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  container_image_tag = "53178d4131882df5753d576d654b4800fc012233"
+  container_image_tag = "efdd181bad4d86fb55e24bc02b1edef813f8d377"
 }

--- a/eopprod/ap-southeast-2/eopprod/services/ecs-eop-data-transformation/module_config.hcl
+++ b/eopprod/ap-southeast-2/eopprod/services/ecs-eop-data-transformation/module_config.hcl
@@ -1,4 +1,4 @@
 # Define some config vars that can be imported by the shared terragrunt config. To keep the config dry.
 locals {
-  container_image_tag = "efdd181bad4d86fb55e24bc02b1edef813f8d377"
+  container_image_tag = "0274ef70b4b1c25578a5e93ab7a2d8935d28ee1d"
 }


### PR DESCRIPTION
production fix for dbt model failure - reduces the size of the plan limits viewer hilltop model to one year's worth of 1 year 1 weeks worth of data as the current model is failing due to running out of space on our current database.